### PR TITLE
Draft: Guided-entry, session resume, and approval UX (reshaped)

### DIFF
--- a/docs/rfcs/guided-entry-session-resume-multi-role.md
+++ b/docs/rfcs/guided-entry-session-resume-multi-role.md
@@ -1,0 +1,503 @@
+# RFC: Guided Entry, Session Resume, and Multi-Role Approvals
+
+**Status:** Draft — **NEEDS RESHAPE before acceptance.** PRs 5 and 7 conflict with the already-accepted [multi-team-approval.md](./multi-team-approval.md) mechanism (which uses per-signer files under `.claude/sdlc/sign-offs/` + `## Required sign-offs` block in gate files + transport ladder; this RFC's PRs 5 and 7 propose an incompatible `approvals.chain` config + `@@SIGNATURE` blocks inside gate files + git-commits-per-signature). Path-A reshape (drop PRs 5 and 7, adjust PRs 3/6/8/9 to speak multi-team-approval's vocabulary) is pending — work continues next session.
+**Author:** Charlton Ho
+**Target:** `lantisprime/claude-sdlc`
+**Date:** 2026-04-20
+
+---
+
+## Relationship to `multi-team-approval.md`
+
+The accepted `multi-team-approval.md` (2026-04-19) defines *how* cross-team sign-off works in this plugin: one file per signer under `.claude/sdlc/sign-offs/`, a `## Required sign-offs` block in each gate file, a reconciler hook, a transport ladder, and an `APPROVALS.md` git mirror. That mechanism is the authoritative design for multi-team approvals in this repo.
+
+This RFC's *complementary* PRs layer on top of that mechanism without touching it:
+- PR 1 `/status`, PR 2 `/start`, PR 3 SessionStart hook, PR 4 plan versioning, PR 6 approval packet, PR 8 `/configure`, PR 9 glossary + `/help` + message library, PR 10 auto next-step hints.
+
+This RFC's *conflicting* PRs need to be dropped or reshaped before acceptance:
+- PR 5 (multi-role approval chain) — proposes `approvals.chain` + `assignments` in `config/tools.json`. Conflicts with multi-team-approval's "`## Required sign-offs` in the gate file, roles declared per-gate" model. **Drop.** Any role-configuration work should extend `approvals.roles` as defined in multi-team-approval §6.4 instead.
+- PR 7 (distributed sign-off via git) — proposes `@@SIGNATURE` blocks inside gate files and commits-per-signature. Conflicts with multi-team-approval's "sign-off files are separate artifacts, one per signer, synced via transport ladder" model. **Drop.** Multi-team-approval's Tier 2 git-central-repo transport already provides distributed sign-off, differently.
+
+Path-A reshape (drop PRs 5 and 7, adjust vocabulary in the rest) is the path forward. This draft preserves today's brainstorming for tomorrow's session.
+
+---
+
+## Summary
+
+Add six small, independent improvements to the claude-sdlc plugin that reduce onboarding friction and support multi-team approval workflows, without modifying any of the plugin's load-bearing invariants.
+
+The changes ship as six separate PRs, each scoped to one concern, each graceful-degrading, each optional by default so existing users see no behavior change until they opt in.
+
+## Motivation
+
+Three concrete problems have surfaced in discussion and in principle, though not yet validated against real usage:
+
+1. **New users don't know where to start.** The plugin exposes eleven commands. A new user doesn't know which to run first, what information the system needs, or whether their task qualifies for `/fix-fast`. Today they either read the README carefully or run `/plan` with incomplete input.
+
+2. **Session resume is invisible.** On SessionStart, `env-detect.sh` reports integrations but not in-flight SDLC work. A user returning to a project with a half-drafted plan has no signal that one exists, and no prompt to continue or revise.
+
+3. **Single sign-off and single-machine sign-off don't scale to distributed contributors.** `gate-signoff` captures one human signature in one Claude Code session on one machine. Open-source contributors approving a plan from different continents, or even a small team with a tech lead in a different office, cannot both sign the same gate today without co-locating at one keyboard. Organizations with formal change control need tech-lead, architect, and approver sign-offs in sequence — typically across three different people on three different machines.
+
+A secondary motivation: after three rounds of design iteration on these problems, the work converged on changes that fit the repo's existing patterns rather than requiring new architecture. This RFC captures that convergence before implementation begins.
+
+## Non-goals
+
+Explicitly not in scope, based on `CLAUDE.md`'s "Things NOT to change" section and prior design discussion:
+
+- Reordering or renaming the 8 phases
+- Adding a 4-phase user abstraction over the 8 internal phases
+- Widening `/fix-fast` eligibility rules
+- Auto-classifying risk from LOC or file count
+- Adding a second convenience path beyond `/fix-fast`
+- Renaming any plan artifact field parsed by hooks
+- Building appeal paths, reviewer-of-reviewers, or retrospective audits
+- Rewriting hooks in Python or JavaScript
+- Bundling multiple changes per PR
+- Auto-running `/configure` on anything other than first install (Layer 0) or explicit command-time need (Layer 2) — Layer 1 (partial/broken config) stays warn-only
+- Auto-writing config without an explicit diff confirmation — `/configure` always shows the proposed change before saving
+
+Deferred work (appeal paths, audit retrospectives, sophisticated delegation) will be reconsidered after real usage generates requirements, not before.
+
+## Proposed changes
+
+### 1. `/status` command — read-only task state
+
+A new command that prints the current in-flight task: active phase, pending gate, blockers, next action. Reads `.claude/sdlc/env.json`, `gates/*.md`, and `plans/*.md`. Writes nothing.
+
+**Files added:** `commands/status.md`, `skills/status/SKILL.md`
+**Files modified:** none
+**Rationale:** Attacks the "where am I, what's blocking me" cognitive load directly. Pure additive, zero regression risk.
+
+### 2. `/start` command — guided intake
+
+A thin wrapper over the existing `plan` skill. Asks the user: task type, UI impact, API impact, size estimate, then prompts for risk-level declaration with required free-text justification. If answers match `/fix-fast` eligibility, offers to route there. Otherwise hands pre-filled answers to the `plan` skill as Plan v0 draft. Prints a disclaimer at handoff reminding the user they are responsible for reviewing and completing the draft before approval.
+
+**Files added:** `commands/start.md`, `skills/start/SKILL.md`
+**Files modified:** `README.md` (command table, quick-start)
+**Rationale:** Serves as the front door for new users without duplicating `/plan`'s logic. Risk as declared judgment, not calculation, matches the plugin's human-in-the-lead principle.
+
+### 3. SessionStart plan check hook
+
+A new hook running alongside `env-detect.sh` on SessionStart. Scans `plans/` and `gates/` and prints one of:
+
+- **No active work** — nudges the user: "Run `/start` to begin."
+- **Drafted-but-unsigned plan** — offers resume or revise.
+- **Signed mid-phase task** — shows active phase and next action.
+- **Awaiting your signature on branch `<name>`** — fires when identity resolves via `git config user.email` or `CLAUDE_SDLC_APPROVER_IDENTITY`, `approvals.assignments` is configured (PR 5), and the resolved identity maps to an unsigned role on an active gate.
+- **Multiple active plans** — lists them.
+
+Writes nothing. Blocks nothing. Matches the existing `env-detect.sh` pattern.
+
+**Output budget (applies to all SessionStart hooks).** Each SessionStart hook is capped at roughly 5 lines of output by convention; anything longer is hidden behind an on-demand command (`/status` for task detail, `/configure --check` for config-validation detail once PR 8 lands). Goal: the first thing a returning user sees is scannable in under a second. This constraint applies to `env-detect.sh`, this hook, and any future SessionStart hook.
+
+**Files added:** `hooks/session-plan-check.sh`
+**Files modified:** `hooks/hooks.json`
+**Rationale:** Surfaces existing state so users can choose to continue, revise, or start new work. The "awaiting your signature" state is the pull-side complement to PR 5/7's push-side CLI output and tracker comments — catches approvers when they next open the repo without the plugin owning notification infrastructure. Warn-only, exit 0.
+
+### 4. Plan versioning and supersede
+
+Adds `Version` and `Status` front-matter to `templates/plan.md`. Material edits to a signed plan — changes to scope, classification, in-scope files, or risk level — trigger a rename of the current file to `<slug>.v1.md` with `Status: superseded`, and creation of `<slug>.v2.md`. Prior gate signatures remain visible on superseded files but do not satisfy the plan-gate for the active version. Non-material edits do not version.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Draft_v1: /start or /plan
+    Draft_v1 --> Signed_v1: gate-signoff passes
+    Signed_v1 --> Signed_v1: non-material edit<br/>(prose, typo)
+    Signed_v1 --> Superseded_v1: material edit<br/>(classification / in-scope / risk)
+    Superseded_v1 --> Draft_v2: auto-create <slug>.v2.md
+    Draft_v2 --> Signed_v2: gate-signoff passes<br/>prior signatures do NOT satisfy
+
+    note right of Superseded_v1
+        Status: superseded
+        Prior signatures remain visible
+        but do not satisfy plan-gate
+        for the active version.
+    end note
+```
+
+The "material edit" prompt fires only when a save touches Classification, In-scope files, In-scope functions, Out-of-scope, or the Risk-level field. All other edits — prose clarification, typo fixes, reformatting — pass silently. Visibility only, no enforcement.
+
+**Soft handling to reduce friction.** Versioning adds concepts (version, supersede, material change) that didn't exist before. Three affordances keep them out of the user's way when possible:
+
+- **Hide version when v1 is the only version.** `/status` and other surfaces render `Plan: <slug>` with no version suffix until v2+ exists. One version costs zero UI.
+- **Narrative prompts, not terse confirms.** Instead of "this is a material edit, confirm?", the prompt names the specific field change and its consequence: "Changing risk level from `medium` to `high` will create plan v2. Your v1 sign-off is archived but won't carry over. Continue? [Y/n]". The *why* is in the message.
+- **One-line confirmation after a version bump.** Post-save: `Saved as v2. v1 archived at plans/<slug>.v1.md (superseded).` User knows what happened and where to find it.
+
+**Files added:** none
+**Files modified:** `templates/plan.md`, `skills/plan/SKILL.md`, `hooks/plan-gate.sh`, `hooks/diff-scope-check.sh`, `docs/SDLC.md`
+**Rationale:** Closes the gap where the plan file itself is mutable after signing. Existing `change-request.md` covers scope changes via ceremony; versioning covers them via the artifact itself. Existing unversioned plans continue to work as `Version: 1` implicit.
+
+### 5. Multi-role approval chain
+
+Extends `gate-signoff` from single sign-off to a configurable approval chain. Adds an `approvals` block to `config/tools.example.json` (no new config file) with chain, assignments, timeout, fallback, and notify keys. Gate-signoff walks the chain in order, prompting each role with the existing URL-as-acknowledgment convention preserved per role.
+
+When the signer does not match the assigned user or group, sign-off fails with a clear message. When assignments are unresolvable (no git config, no env var, empty assignments), the check degrades to a warning and captures the signature with a `role_verified: false` flag rather than blocking. Rejection requires a free-text reason. Role overlap is allowed and logged, not blocked.
+
+The optional `notify.on_signature` key controls push-side notification when a role signs. Values: `"none"` (default, no behavior change) or `"comment_on_workitem"` (post a comment to the work item already linked in the plan, naming the role just signed and the next assignee). Uses the same work-item integration the plugin already relies on for traceability — no new dependency. If the tracker is unreachable, unconfigured, or authentication fails, the hook degrades to local print and records `notification_sent: false` in the signature block. This pairs with PR 3's SessionStart "awaiting your signature" state to give both push- and pull-side signals without the plugin owning notification infrastructure.
+
+**Chain visibility — one render across all surfaces.** When an approval chain exists, a single one-line render shows its state everywhere the chain is surfaced: `/status`, the SessionStart "awaiting your signature" output (PR 3), and tracker-comment notifications (the `notify` feature above). Format:
+
+```
+Chain: tech_lead ✓ alice  →  architect ⏳ bob (awaiting)  →  security □ carol
+```
+
+Symbols: `✓` signed, `⏳` awaiting current user or next assignee, `□` pending future approver. A shared helper in `skills/gate-signoff/` renders the line from gate-file state; all three surfaces consume the same helper so users learn one visual pattern, not three. Appears only when a chain is configured — single sign-off users see nothing new.
+
+If the `approvals` block is absent, behavior is exactly today's single sign-off.
+
+**Files added:** none
+**Files modified:** `config/tools.example.json`, `templates/gate.md`, `skills/gate-signoff/SKILL.md`, `hooks/phase-gate.sh`, `docs/SDLC.md`
+**Rationale:** Separates authority from visibility. Lets organizations declare their chain in config without touching code. Default-off means zero impact on current users.
+
+### 6. Approval packet
+
+A derived artifact compiled at sign-off time containing scope, delta from previous approved version, risk level and justification, mitigation and rollback plan, traceability links, decision required, and reason for approval request. Includes a header disclaimer reminding reviewers the packet is a summary and source artifacts remain authoritative. Every section links to its source, not just references it.
+
+If the compiled packet exceeds roughly two screens (around 100 lines), the skill prompts the author to summarize further. Warning, not block.
+
+**Files added:** `templates/approval-packet.md`
+**Files modified:** `skills/gate-signoff/SKILL.md`, `docs/SDLC.md`
+**Rationale:** Reviewers today must stitch together four or more files to understand what they're signing. The packet is a compile step, not new information.
+
+### 7. Distributed sign-off via git
+
+Makes `gate-signoff` resumable across machines so each role in the approval chain can sign from their own environment. Each signature becomes its own commit; the gate file is a collaboratively-edited artifact rather than a single-session output.
+
+When `gate-signoff` runs, it reads the existing gate file and detects which signatures are already present. It prompts only for the next missing role in the chain. It writes just that signature block and does not overwrite prior signatures. The approver commits and pushes; the next approver in the chain pulls the branch, runs `gate-signoff`, and signs their block.
+
+```mermaid
+sequenceDiagram
+    actor A as Approver A (tech_lead)
+    actor B as Approver B (architect)
+    participant Gate as gate/<slug>.md
+    participant Local as Local git
+    participant Remote as Git remote
+
+    A->>Local: gate-signoff
+    Local->>Local: Resolve identity<br/>(git config user.email)
+    Local->>Local: Match to 'tech_lead' in assignments
+    Local->>Gate: Write tech_lead signature block
+    Local-->>A: Commit this signature? [Y/n]
+    A->>Local: Y
+    Local->>Local: git commit (role_verified=true)
+    Local->>Remote: git push
+    Local-->>A: "Next approver: architect — bob@acme.com"
+
+    B->>Remote: git pull <branch>
+    Remote-->>B: Branch with tech_lead signature
+    B->>Local: gate-signoff
+    Local->>Gate: Detect existing tech_lead block, skip
+    Local->>Local: Resolve identity → match 'architect'
+    Local->>Gate: Append architect signature block
+    Local->>Local: git commit + push
+    Local-->>B: "All roles signed. Gate complete."
+```
+
+Role identity is resolved from `git config user.email` as the primary source, with `CLAUDE_SDLC_APPROVER_IDENTITY` as an override for environments where git config is unavailable. The resolved identity is matched against the `assignments` map from PR 5.
+
+The commit containing each signature becomes part of the audit trail. Git authorship, timestamp, and optionally GPG signing (`git commit -S`) layer on top of the URL-as-acknowledgment convention. The gate file itself continues to quote each human's raw URL acknowledgment verbatim.
+
+Optional: the hook or skill can prompt "Commit this signature now? [Y/n]" after writing, making the git flow explicit to users who may not realize the sign-off needs to land in a commit.
+
+**Graceful degradation — summary.** PR 7 has more failure modes than PR 5 and treats each according to intent. The plugin degrades, hands off, or refuses depending on which layer is missing. The short version:
+
+- **Not in a git repo** → hand off to PR 5 in-session multi-role
+- **Identity unresolvable and `assignments` absent** → capture signature with `role_verified: false`
+- **Identity unresolvable but `assignments` configured** → *refuse*, with a clear message (intentional, not a gap)
+- **Identity resolved but mismatches assignment** → *refuse* (intentional)
+- **No remote or push rejected** → local commit stands, print next-step guidance
+- **`commit -S` requested but signing key missing** → sign unsigned, flag `commit_signed: false`
+
+The full decision tree, including test cases and interaction with branch protection, lives in the implementation note at `docs/rfcs/notes/guided-entry-pr7-degradation.md` (added alongside the RFC). Implementers should read the note before writing the skill changes. **Note:** this whole PR is marked for drop in the reshape pass — see the "Relationship to multi-team-approval.md" section.
+
+**Files added:** `docs/rfcs/notes/0001-pr7-degradation.md` (implementation note)
+**Files modified:** `skills/gate-signoff/SKILL.md`, `templates/gate.md` (structure for multiple independent signature blocks), `docs/SDLC.md`
+**Rationale:** The existing sign-off model assumes one human at one keyboard. Contributors to an open-source repo, or distributed teams, cannot both sign the same gate without co-locating. Git is already the repo's state store, branches are already the coordination mechanism, PRs are already how changes cross machines — treating gate files as commit-by-commit artifacts uses infrastructure already present. No new services, no new protocols. Preserves all invariants: still human-in-the-lead, still URL-acknowledged, still fresh per role, with an explicit degradation matrix rather than the single-line fallback PR 5 could offer.
+
+### 8. Guided configuration (`/configure`)
+
+Replaces manual editing of `config/tools.json` for first-time setup and common reconfigurations. Extends `env-detect.sh` with a config-validation pass; commands that need config they're missing auto-invoke `/configure` in scoped mode and resume afterward. Power users can still edit config files by hand — `/configure` is an on-ramp, not a replacement.
+
+**Files added:** `commands/configure.md`, `skills/configure/SKILL.md`
+**Files modified:** `hooks/env-detect.sh`, every skill that reads config (adds `config_requirements` frontmatter), `docs/SDLC.md`
+
+**Four-layer invocation model.**
+
+| Layer | Trigger | Behavior |
+|---|---|---|
+| 0 | Fresh install: no `config/tools.json`, no `tools.local.json`, no content in `plans/` or `gates/`, inside a git repo | Auto-invoke `/configure` on the first user turn. First prompt is opt-out-first: `[Y] continue / [n] skip / [?] help`. On successful completion, prompt once: `Start a task now? [Y/n]` — if Y, auto-invoke `/start` so "install → configure → first task" is one unbroken flow. |
+| 1 | Partial or broken config, no command yet invoked | SessionStart warn-only. Informational: "commands will auto-prompt for config they need when you run them." No auto-invoke. |
+| 2 | Command invoked, its required config is missing or malformed | Auto-invoke `/configure --needs <keys>` scoped to the specific fields the command declared. Resume the original command on success; abort with a clear "cannot proceed without `<field>`" on cancel. |
+| 3 | Config unparseable (invalid JSON, structurally broken) | Refuse. `/configure` offers rebuild-from-scratch, backing up the current file to `config/tools.json.bak`. |
+
+The rule: **if user intent is unambiguous, auto-invoke; if not, warn.** Layers 0 and 2 mean a new user never has to learn that `/configure` exists — the commands they're already running pull it in at the right moments. `/configure` as a standalone command is only for proactive changes (adding a role, switching tracker), a smaller audience that's happy to type it.
+
+**Scoped mode (`/configure --needs <key[,key...]>`).** Asks only about the specified fields, skips the rest, exits when done or cancelled. Used by Layer 2 so commands don't drag the user into unrelated config questions. Example: `/plan` invokes `/configure --needs tracker.type,tracker.project`, not the full wizard.
+
+**Resume semantics.** When Layer 2 invokes `/configure`, the original command is stashed. On successful completion, it resumes with the new config in scope. On cancel or decline, the original command aborts with a clear message naming the missing field. No silent success, no orphaned state.
+
+**Config requirements declaration.** Each skill that reads config adds a `config_requirements` block to its SKILL.md frontmatter:
+
+```yaml
+config_requirements:
+  - key: tracker.type
+    required: true
+    on_skip: refuse
+  - key: tracker.auth_token
+    required: false
+    on_skip: degrade_with_todo_links
+```
+
+Layer 2 reads this block to decide what to pass to `/configure --needs` and how to handle cancel. Keeps the auto-invoke logic declarative — no per-command branching.
+
+**Public vs. local config.** Non-secret keys (chain, assignments, notify preference, tracker.type, tracker.project) go to `config/tools.json` (version-controlled). Auth tokens and anything secret go to `config/tools.local.json`. `/configure` adds `config/tools.local.json` to `.gitignore` on first write if not already present. Always shows a diff of the proposed change before saving — never writes without explicit confirmation.
+
+**Dry-run.** `/configure --check` parses current config, runs the validation pass, prints what would be asked. No prompts, no writes. Mirrors `/status`'s read-only posture.
+
+**First-install question budget: 8 questions maximum.** Layer 0's wizard is capped to keep onboarding from becoming a tax. Progressive disclosure enforces the cap:
+
+1. Tracker type? (Linear / GitHub Issues / Jira / none)
+2. Tracker auth token? (only if tracker chosen; stored in `tools.local.json`)
+3. Tracker project key or repo? (only if tracker chosen)
+4. Will this project need multi-person sign-off? (Y/n) — **if `n`, skip questions 5–8 entirely and finish**
+5. Which roles in the chain? (comma-separated; default: `tech_lead, approver`)
+6. Email/identity for each role? (one prompt per role; `git config user.email` pre-filled as default for the first unassigned slot)
+7. Notify on signature? (none / comment on work item)
+8. Require signed commits (GPG/SSH) for sign-off? (default: no)
+
+Single sign-off users answer 3 questions and finish. Multi-role users answer up to 8. No question presents a free-text field without a sensible default offered where possible. The budget is a ceiling, not a target — adding a 9th question requires justifying why it can't be deferred to a later reconfigure flow.
+
+**Context-aware defaults.** `/configure` inspects the environment before prompting and pre-selects likely answers: `.github/` directory → suggest GitHub Issues; `.linear.yml` or the Linear CLI on PATH → suggest Linear; `git remote -v` containing `github.com` → suggest GitHub Issues as the secondary default. User can always override; the point is to make the default the user's probable answer so accept-and-continue is a single keystroke.
+
+**Rationale.** `/configure` is the largest single cognitive-load win in this RFC. Current users must read `config/tools.example.json`, infer the schema, and know which fields are secret. `/configure` asks plain-language questions, validates as it goes, handles the public/local split automatically, and — because Layers 0 and 2 auto-invoke — removes the need to memorize the command at all.
+
+### 9. Glossary, `/help`, and shared message library
+
+Three user-facing-text assets that ship together because they share the same audience (anyone reading plugin output) and the same failure mode (inconsistent wording confuses users). Bundling keeps the vocabulary, the lookup, and the message phrasing coordinated.
+
+**Glossary.** Adds `docs/GLOSSARY.md` defining the vocabulary this RFC introduces (plan version, supersede, material change, approval chain, role, assignment, approver, packet, `role_verified`, `commit_signed`, `notification_sent`, `config_requirements`, Layer 0–3) and the pre-existing terms the RFC builds on (plan, gate, sign-off, phase, in-scope/out-of-scope, change-request). Each entry: one-sentence definition, one-sentence context, link to the section where it's used.
+
+**`/help` command.** Bridges vocabulary, commands, and current state into one "I'm confused" destination:
+
+- `/help` (no arguments) — prints (1) current SDLC state (mirror of `/status` output), (2) the command table with one-line descriptions, (3) the five most-relevant glossary terms for the current state. Three-section layout, clearly delimited, budgeted to fit in one screen.
+- `/help <term>` — prints just the matching glossary entry.
+- `/help <command>` — prints the command's purpose, arguments, and a usage example.
+
+Showing state alongside vocabulary means a confused user doesn't have to guess whether to run `/status` or `/help` — the bridge-command handles the overlap and points them at the narrower commands when they know what they need.
+
+**Shared message library.** Adds `skills/_shared/messages/` — a catalog of reusable user-facing strings keyed by event ID. Every skill that prints a refuse, degrade, handoff, or warn message reads from the catalog rather than hardcoding text. Examples: `identity_unresolvable_with_assignments`, `tracker_notification_failed`, `config_unparseable`, `chain_role_already_signed`.
+
+Benefits: (1) wording stays consistent across commands — "identity unresolvable" reads identically whether it's printed from `gate-signoff`, `/configure`, or `/status`; (2) translation/rewording is one file, not a grep across every skill; (3) the `/help` glossary can cross-link to the messages that use each term.
+
+**Files added:** `docs/GLOSSARY.md`, `commands/help.md`, `skills/help/SKILL.md`, `skills/_shared/messages/` (catalog files, one per event category)
+**Files modified:** `README.md` (point at GLOSSARY for term lookup), every skill that prints refuse/degrade/handoff/warn messages (reads from the message catalog instead of hardcoding)
+**Rationale:** This RFC introduces roughly ten new nouns on top of existing vocabulary and many new failure-mode messages. Forcing users to grep docs to recover a definition, or forcing wording to drift across three skills that all say "identity unresolvable" slightly differently, are both avoidable frictions. Bundling the glossary, the `/help` bridge, and the shared message catalog keeps the user-facing text layer coherent. Ships after PR 5 so the full new vocabulary and the full new set of messages exist when the catalog is first populated.
+
+### 10. Automatic next-step hints
+
+Every user-visible command appends a single "Next:" line at the end of its output, suggesting the most likely next action based on current state. This is not a new command — it is an output convention every skill adopts. The user never runs anything new; the commands they already run get one extra line that teaches the workflow.
+
+Examples:
+
+- `/plan` completes with an unsigned plan → `Next: /status to review, or /gate-signoff when ready.`
+- `/gate-signoff` completes with chain fully signed → `Next: begin analyze phase.`
+- `/configure` completes via Layer 2 auto-invoke → *no "Next:" printed — the resumed command IS the next step.*
+- `/status` with no active work → `Next: /start to begin a new task.`
+- `/status` with a signed mid-phase task → `Next: continue with <phase> commands, or /gate-signoff to approve.`
+
+**Declarative per-skill.** Each skill's SKILL.md gains a `next_suggestions` frontmatter block. The suggestion is chosen by matching the `when` condition against current state:
+
+```yaml
+next_suggestions:
+  - when: plan_drafted_and_unsigned
+    suggest: "/status to review, or /gate-signoff when ready"
+  - when: plan_signed_and_no_phase_active
+    suggest: "begin analyze phase"
+```
+
+A shared helper at `skills/_shared/next-hint.sh` resolves `when` conditions against `.claude/sdlc/env.json`, `gates/*.md`, and `plans/*.md` state, and prints the first matching `suggest`. If no condition matches, no "Next:" line is printed — silence is better than a wrong hint.
+
+**Suppression — three honest signals, no guessing at "is this a power user."**
+
+1. **Auto-suppress on non-TTY.** If stdout isn't a TTY (piped output, script, CI), no "Next:" line prints. Zero config, handles automation correctly.
+2. **Fade-after-3 per unique hint.** Each distinct `suggest` string has a shown-count tracked in `.claude/sdlc/hints.jsonl`. Once a user has seen a given hint three times, it silently stops appearing for them — regardless of how often the `when` condition fires. New hints (new `when` conditions that haven't been encountered) still get full treatment. The user doesn't classify themselves; each hint retires itself once it has served its teaching purpose.
+3. **Explicit opt-out.** `display.next_hints: off` in `config/tools.json` suppresses all hints. For users who want them gone entirely without waiting for the fade.
+
+Combined, these mean: scripts never see hints; new users see them until they internalize (typically 1–3 appearances); returning users aren't re-taught what they already know; anyone can opt out if they want. No heuristic tries to label the human — the system adapts through exposure, which is honest.
+
+**Files added:** `skills/_shared/next-hint.sh`
+**Files modified:** every skill's SKILL.md (adds `next_suggestions` frontmatter and invokes `next-hint.sh` at the end of its output), `docs/SDLC.md`
+
+**Rationale.** Cognitive load during a multi-step workflow isn't about the *current* command — it's about "what now?" Users currently have to remember the workflow or re-read docs. Making every command's output self-suggest the next move means users learn the workflow by *using* it. Scales across the entire surface with one convention. The `when`-condition pattern keeps suggestions state-aware rather than generic, so the hint is right for *this* user's *current* situation. Ships last because the convention is easiest to apply uniformly once every skill's output shape is stable.
+
+## Dependency graph and ship order
+
+```
+PR 1 (status)             — independent
+PR 2 (/start)             — independent
+PR 3 (session check)      — independent; interim caveat points users at PR 4
+PR 4 (versioning)         — independent; strengthens PR 3's revise path
+PR 8 (/configure)         — independent; retroactively reduces setup friction for PR 1–4, unlocks PR 5
+PR 5 (multi-role chain)   — much easier to adopt after PR 8
+PR 9 (glossary + /help)   — best after PR 5 (full new vocabulary has landed)
+PR 7 (distributed signoff) — depends on PR 5 (reads the chain and assignments)
+PR 6 (approval packet)    — best after PR 4 and PR 5
+PR 10 (auto next-step hints) — ships last; applied uniformly across every skill once their outputs are stable
+```
+
+**Ship order:** 1 → 2 → 3 → 4 → 8 → 5 → 9 → 7 → 6 → 10
+
+PR 3 ships before PR 4 because session-resume is the fastest-visible cognitive-load win. Until PR 4 lands, PR 3's "drafted-but-unsigned" and "signed mid-phase" outputs include a short caveat: "revising a signed plan currently mutates it in place; versioning ships in PR 4." PR 8 lands immediately before PR 5 because the configuration surface jumps significantly at PR 5 — without `/configure`, teams would have to hand-edit JSON to adopt multi-role approval, which is exactly the friction this RFC is trying to remove. PR 8 also retroactively improves onboarding for PRs 1–4 (tracker config for `/plan`, etc.) by providing a guided path to whatever config they need. PR 9 lands after PR 5 so the glossary is written once against the full new vocabulary, not grown piecemeal. PR 7 lands immediately after PR 5 because multi-role in a single session is a half-feature for this repo's primary audience — open-source contributors who do not share a keyboard. PR 6 ships after PR 7 so the packet's signature section reflects the final shape of PR 5 + PR 7 together. PR 10 is last because it's a cross-cutting output convention — applying it to every skill is cleanest when each skill has settled into its final output shape.
+
+**Estimated effort:** roughly one to two weeks of focused work for one engineer, or two to three weeks calendar with testing, documentation, and iterating on skill descriptions until they trigger reliably.
+
+## Alignment with design principles
+
+| Principle | How this RFC preserves it |
+|---|---|
+| Human in the lead | No PR adds auto-approve. Every gate still needs fresh URL-acknowledged sign-off. PR 5 and PR 7 together add more humans across more machines, not fewer. |
+| Plan before code | No PR loosens `plan-gate.sh`. PR 4 strengthens it — versioning invalidates stale gates. |
+| Surgical edits | Each PR is one concern. No PR spans unrelated skills or hooks. |
+| Work-item traceability | No PR adds a bypass. PR 6 makes traceability more visible via the packet; PR 7 makes each signature a git commit, strengthening the audit trail. |
+| Graceful degradation | Every new config key is optional. Missing `approvals` block means current behavior. Missing git config in PR 7 degrades to same-session multi-role from PR 5. |
+| Stack-agnostic | No hardcoded tool names. All new hooks use POSIX bash. No new runtime dependencies. PR 7 uses only `git`, already a hard dependency. |
+
+## What we will measure
+
+Following the existing `token-tracker.sh` pattern: append JSONL lines to a history file. No dashboards, no committed percentage targets.
+
+- Time from `/start` to signed plan gate
+- Number of intake iterations before plan submission
+- Number of plan versions per task (PR 4 onward)
+- Approval cycle time per role (PR 5 onward)
+- Packet length per task (PR 6 onward)
+- `/configure` invocation source: Layer 0 auto-launch, Layer 2 resume, or manual (PR 8 onward)
+- `/help <term>` lookups by term — which vocabulary confuses users most (PR 9 onward)
+- Next-hint accept rate: did the user's next command match the suggested "Next:" line (PR 10 onward)
+
+Metrics describe reality. They do not predict it. No improvement percentages are committed in this RFC — baseline first, interpret later.
+
+## Alternatives considered
+
+**A rewrite with new architecture.** Three design iterations proposed new directory hierarchies (`.claude/sdlc/tasks/<task-id>/`), a new config file (`approval_config.json`), a new state machine, and commands prefixed `/sdlc:*`. Rejected because the repo already implements most of this via `plans/<slug>.md`, `config/tools.json`, gate files, and the existing command set. Building parallel structure would duplicate rather than improve.
+
+**A 4-phase user abstraction over the 8 internal phases.** Considered in two design rounds. Rejected because exposing both creates a dual vocabulary users must reconcile against error messages, logs, and hooks that speak the 8-phase language. One surface vocabulary is less cognitive load than two.
+
+**Auto-classified risk from LOC and file count.** Considered in design v2. Rejected because LOC thresholds create an illusion of determinism that doesn't hold — a 50-line change to rate-limiting logic is not the same risk as a 50-line rename. Declared judgment with required justification is the honest alternative.
+
+**A forced "reviewer must confirm traceability" checkbox at sign-off.** Considered and rejected. A forced checkbox is friction without function; reviewers who would skip traceability will click the box, reviewers who check it already do so. PR 6's source-link requirement is the nudge; the URL-as-acknowledgment convention is the non-trivial ack.
+
+**Appeal paths, reviewer-of-reviewers, sophisticated delegation.** Deferred. Real usage will generate specific requirements; pre-building governance for abuse cases that may not occur is how systems become unusable.
+
+**A centralized sign-off service or external API for PR 7.** Considered and rejected. Would introduce a network dependency, require hosting, and create a second source of truth competing with the repo. Git commits already give cryptographic authorship, ordered history, and a shared transport — no service needed. Teams that want cryptographic strength beyond commit authorship can opt into `git commit -S` without the plugin knowing or caring.
+
+## Open questions
+
+1. **"Unresolvable assignments" definition in PR 5.** Four cases: no git config, no env var, `assignments` key absent, `assignments` key present but empty. Default proposal: all four degrade to warning-plus-flag. Worth confirming before implementation.
+
+2. **Packet length threshold.** Two screens, roughly 100 lines, is a soft target. The actual number should come from observing real packets in dogfooding rather than committing now.
+
+3. **PR 7 commit flow.** Should `gate-signoff` commit the signature automatically, or prompt the user to commit? Auto-commit is cleaner UX but couples the plugin to a git write. Prompting preserves the "plugin proposes, human acts" posture. Default proposal: prompt, with a config flag to auto-commit for teams that want it.
+
+4. **PR 7 and branch protection.** If the repo has branch protection rules requiring PR review, the signature commits may need to land on a feature branch rather than directly on main. The plugin should not mandate a workflow — it writes the commit; how it's merged is the team's concern.
+
+5. **PR 7 identity spoofing risk.** `git config user.email` is trivially changeable. A malicious contributor could set it to impersonate an approver. Mitigation options: (a) accept the risk — existing sign-off has the same property, just more tightly bound to one session; (b) enable branch protection with required PR review so signature commits cannot land on a protected branch without a second human approving the merge — the pragmatic baseline; (c) opt into `git commit -S` with GPG or SSH verification against a published keyring for cryptographic authorship; (d) defer stronger identity to a future PR. Default proposal: (a) for now, document the risk clearly, recommend (b) for teams that want a mitigation today, allow teams to opt into (c).
+
+## Pending discussions
+
+Directions that surfaced during design iteration and are worth resolving before or alongside implementation, but haven't been decided yet. Captured here so they aren't lost; each can fold into an existing PR, become a new PR, or defer to post-ship.
+
+### A. Workflow templates in `/configure`
+
+Offer named presets at Layer 0 question 5 so users with no opinion don't have to design a chain from scratch:
+
+- **Solo developer** — no chain, just self sign-off; skips questions 5–8.
+- **Small team** — `tech_lead, approver`; notify = `none`; auto_commit = `false`.
+- **Open source** — `maintainer, approver`; notify = `comment_on_workitem`; distributed sign-off (PR 7) enabled.
+- **Enterprise** — `tech_lead, architect, security, approver`; notify = `comment_on_workitem`; require_signed_commits = `true`.
+- **Custom** — free-form list (today's default).
+
+Each preset bundles matching notify/auto_commit/require_signed_commits defaults. Would fold into §8 if accepted. **Cognitive-load impact: high** — turns "design your approval workflow" into "pick your situation."
+
+### B. Back/cancel navigation in interactive flows
+
+Every interactive prompt across `/configure`, `/start`, and `gate-signoff` supports:
+
+- `b` — back to the previous question (answers already given are preserved as defaults)
+- `?` — contextual help for the current prompt
+- `q` — quit without saving
+
+Implemented once in `skills/_shared/prompt.sh` and consumed by every skill that prompts. **Cognitive-load impact: medium** — lowers the stakes on any individual answer; users stop re-reading every question for fear of picking wrong.
+
+### C. Error-message audit to the three-part template
+
+Once PR 9's shared message library exists, every user-facing error and warning in the plugin gets audited and rewritten to match the three-part template PR 7's refusal messages already follow:
+
+1. **What happened** ("Identity unresolvable for role 'architect'")
+2. **Why** ("no git config user.email, no CLAUDE_SDLC_APPROVER_IDENTITY set")
+3. **What to do** ("Run `/configure --needs assignments.architect`, or set git config")
+
+Mechanical once the catalog exists. Could be part of PR 9 scope or ship as a PR 9-follow-on. **Cognitive-load impact: medium-high** — failure moments are peak anxiety; consistent message shape collapses the panic-to-fix cycle.
+
+### D. Integration with Claude Code's native TodoWrite
+
+When a user enters a phase, the plugin could auto-populate Claude Code's native todo list with that phase's checklist. Phase work becomes visible in the same place the user tracks everything else — less context switching between "what does the plugin want?" and "what am I doing?"
+
+Tension: the plugin's design principles claim stack-agnostic posture, but Claude Code is its native environment, and integrating there doesn't break agnosticism for other environments (the integration is gated on Claude Code being present). **Cognitive-load impact: potentially high.** Deferred pending usage data — does the context-switch cost actually bite in practice?
+
+### E. Per-phase checklist rendering in `/status`
+
+`/status` currently shows task state at a high level ("signed mid-phase task"). When in-phase, it could render the phase's checklist with completion markers:
+
+```
+Phase 3 of 8 — analyze
+  [x] Read CLAUDE.md and relevant READMEs
+  [x] Identify in-scope files
+  [ ] Identify out-of-scope files
+  [ ] Confirm risk level
+  [ ] Document assumptions
+Next: continue analyze, or /gate-signoff when complete.
+```
+
+Turns opaque "mid-phase" into concrete progress. Would expand §1's `/status` spec if accepted. **Cognitive-load impact: medium.**
+
+## Security and privacy considerations
+
+No new external services. No new network calls. No new secrets handling beyond what the plugin already does. All state remains local to `.claude/sdlc/` and to the repo's git history. Role assignments in `config/tools.json` are user-visible and version-controlled; teams concerned about role information in repo history should place assignments in a `tools.local.json` added to `.gitignore`.
+
+**PR 7 specifically.** Identity for sign-off derives from `git config user.email`, which any contributor can set. This is the same trust model the repo already uses for commit authorship — anyone can author a commit as anyone. Teams that need stronger guarantees should (a) enable branch protection so signature commits go through PR review before merging, and (b) opt into `git commit -S` with GPG or SSH signing and verify against a known keyring at review time. The plugin does not enforce these; it records the signature and leaves verification to the team's git workflow.
+
+## Backward compatibility
+
+Every change is default-off or graceful-degrading.
+
+- Existing plan files without `Version`/`Status` front-matter behave as `Version: 1, Status: active`
+- Existing `config/tools.json` without an `approvals` block behaves as today's single sign-off
+- The new SessionStart hook is additive; removing it returns behavior to current
+- `/status` and `/start` are new commands; existing `/plan`, `/analyze`, etc. are untouched
+- The approval packet is a derived artifact; source files remain authoritative and unchanged in shape
+- PR 7 is additive to PR 5: in the same session, multi-role still works exactly as PR 5 describes. Distributed sign-off is opt-in by convention — each approver runs `gate-signoff` on their own machine rather than all in one session
+- PR 8 is additive. Hand-edited `config/tools.json` continues to work untouched; `/configure` only modifies fields the user is actively configuring and always shows a diff first. Users who prefer manual editing never have to invoke it (beyond the first-install prompt, which they can skip)
+- PR 9 is purely additive — existing users see no change until they run `/help` or read the glossary
+- PR 10 modifies output of every skill to append a "Next:" line, but adds no new behavior. Skills with no matching `when` condition print nothing extra, identical to today's behavior
+
+No migration required for existing users.
+
+## Implementation checklist
+
+- [ ] PR 1: `/status` command + skill
+- [ ] PR 2: `/start` command + skill
+- [ ] PR 3: SessionStart plan check hook
+- [ ] PR 4: Plan versioning and supersede
+- [ ] PR 8: `/configure` command + env-detect config validation
+- [ ] PR 5: Multi-role approval chain (+ optional tracker notification, + shared chain-visibility render)
+- [ ] PR 9: Glossary + `/help` (with bridge behavior) + shared message library
+- [ ] PR 7: Distributed sign-off via git
+- [ ] PR 6: Approval packet
+- [ ] PR 10: Automatic next-step hints (output convention adopted by every skill)
+- [ ] Dogfood on 2–3 real projects
+- [ ] Collect observed blockers; generate next backlog from real usage
+
+---
+
+*End of RFC.*

--- a/docs/rfcs/guided-entry-session-resume-multi-role.md
+++ b/docs/rfcs/guided-entry-session-resume-multi-role.md
@@ -212,24 +212,30 @@ Layer 2 reads this block to decide what to pass to `/configure --needs` and how 
 
 **Dry-run.** `/configure --check` parses current config, runs the validation pass, prints what would be asked. No prompts, no writes. Mirrors `/status`'s read-only posture.
 
-**First-install question budget: 8 questions maximum.** Layer 0's wizard is capped to keep onboarding from becoming a tax. Progressive disclosure enforces the cap:
+**First-install question budget: 8 questions maximum.** Layer 0's wizard is capped to keep onboarding from becoming a tax. Progressive disclosure enforces the cap.
+
+**Scope of the multi-team questions (Q5–Q8).** Three things the accepted RFC leaves out of config are deliberately absent from this wizard:
+
+- **No per-role email assignments.** Signer identity lives in the `signer:` field of each sign-off file (accepted RFC §3.1, §3.6), never in config. The wizard does not ask "who signs what."
+- **No signed-commit enforcement.** Cryptographic attestation is a team-workflow concern outside the plugin (accepted RFC §3.9). Teams that want `git commit -S` should configure git itself.
+- **No tracker-notification-on-signature.** Not in accepted-RFC scope; would need its own mini-RFC before this wizard could prompt for it.
+
+The questions:
 
 1. Tracker type? (Linear / GitHub Issues / Jira / none)
 2. Tracker auth token? (only if tracker chosen; stored in `tools.local.json`)
 3. Tracker project key or repo? (only if tracker chosen)
-4. Will this project use multi-team sign-off? (Y/n) — **if `n`, skip questions 5–7 and finish**
-5. Role vocabulary? (suggested 9-role set from accepted RFC §6.4 / custom comma-separated list) — writes `approvals.roles`
-6. Sync sign-off files across machines? (none / network share / central git repo / defer)
+4. Will this project use multi-team sign-off? (Y/n) — **if `n`, skip questions 5–8 and finish**
+5. Role vocabulary? (suggested 9-role set from accepted RFC §6.4 / custom comma-separated list) — writes `approvals.roles`. *No per-role email prompt follows; identity lives in the sign-off file itself per accepted RFC §3.6.*
+6. Sync sign-off files across machines? (none / network share / central git repo / defer). *Transport is a file-delivery mechanism, not an identity source — no signed-commit prompt follows.*
 7. (Conditional on Q6) Share path or central git repo URL? — writes `approvals.share_path` or `approvals.git_repo`
 8. Enable `display.session_signoff_hints` personalization in PR 3? (Y/n; default Y)
 
 Single sign-off users answer 3 questions and finish. Multi-team users answer up to 8. No question presents a free-text field without a sensible default offered where possible. The budget is a ceiling, not a target — adding a 9th question requires justifying why it can't be deferred to a later reconfigure flow.
 
-**Deliberately excluded from Q5–Q8:** per-role email assignments (accepted RFC keeps signer identity in the sign-off file, not in config), signed-commit enforcement (accepted RFC §3.9 treats cryptographic attestation as a team-workflow concern outside the plugin), and tracker-notification-on-signature (not in accepted RFC scope; would need its own mini-RFC to land).
-
 **Context-aware defaults.** `/configure` inspects the environment before prompting and pre-selects likely answers: `.github/` directory → suggest GitHub Issues; `.linear.yml` or the Linear CLI on PATH → suggest Linear; `git remote -v` containing `github.com` → suggest GitHub Issues as the secondary default. User can always override; the point is to make the default the user's probable answer so accept-and-continue is a single keystroke.
 
-**Rationale.** `/configure` is the largest single cognitive-load win in this RFC. Current users must read `config/tools.example.json`, infer the schema, and know which fields are secret. `/configure` asks plain-language questions, validates as it goes, handles the public/local split automatically, and — because Layers 0 and 2 auto-invoke — removes the need to memorize the command at all. After reshape, the question bank is *smaller* than the pre-reshape draft (per-role assignments and signed-commit enforcement dropped out), so onboarding is faster, not slower.
+**Rationale.** `/configure` addresses a concrete, named friction: today's users must read `config/tools.example.json`, infer the schema, and know which fields are secret. `/configure` asks plain-language questions, validates as it goes, handles the public/local split automatically, and — because Layers 0 and 2 auto-invoke — removes the need to memorize the command at all. The question bank stays tight: three questions for single-signer users, up to seven for multi-team users, with one optional display preference.
 
 ### 9. Glossary, `/help`, and shared message library
 
@@ -315,7 +321,12 @@ PR 10 (auto next-step hints) — ships last; applied uniformly across every skil
 
 **Ship order:** 1 → 2 → 3 → 4 → 8 → 9 → 6 → 10
 
-PR 3 ships before PR 4 because session-resume is the fastest-visible cognitive-load win. Until PR 4 lands, PR 3's "drafted-but-unsigned" and "signed mid-phase" outputs include a short caveat: "revising a signed plan currently mutates it in place; versioning ships in PR 4." PR 8 lands immediately before PR 9 because the configuration surface introduces `approvals.roles` + transport config, and the glossary is cleaner if written against a stable config surface. PR 9 lands after PR 8 so the glossary is written once against the full new vocabulary, not grown piecemeal. PR 6 lands after PR 4 so the packet's delta section knows the version shape, and after PR 9 so glossary cross-links work. PR 10 is last because it's a cross-cutting output convention — applying it to every skill is cleanest when each skill has settled into its final output shape.
+The ordering rationale separates hard dependencies from soft preferences:
+
+- **Hard:** PR 10 must ship last — it rewrites every skill's output shape and is cleanest when every other skill has settled. PR 6 uses PR 4's version machinery in its delta section, so PR 4 precedes it.
+- **Soft (quality-of-rollout):** PR 3 ships before PR 4 because session-resume is the fastest-visible cognitive-load win, not because PR 4 depends on it. Until PR 4 lands, PR 3's "drafted-but-unsigned" output includes a short caveat ("revising a signed plan currently mutates it in place; versioning ships in PR 4"). PR 9 ships after PR 8 because the glossary reads better when `approvals.roles` and the transport config keys are already user-facing; PR 9 would still ship fine before PR 8 with a shorter initial glossary. PR 6 is placed after PR 9 so packet cross-links into the glossary work on day one.
+
+No two PRs block each other outside PR 4→6 and PR 10-last; the rest of the order is a rollout preference, not a constraint.
 
 **Estimated effort:** roughly one week of focused work for one engineer, or one-and-a-half to two weeks calendar with testing, documentation, and iterating on skill descriptions until they trigger reliably. (Reduced from pre-reshape estimate because PRs 5 and 7 represented roughly one-third of the original scope.)
 
@@ -361,6 +372,19 @@ Metrics describe reality. They do not predict it. No improvement percentages are
 
 **Appeal paths, reviewer-of-reviewers, sophisticated delegation.** Deferred. Real usage will generate specific requirements; pre-building governance for abuse cases that may not occur is how systems become unusable.
 
+## Open questions
+
+Questions that must be answered before the corresponding PR lands. Each lists a proposal; reviewers confirm or replace with an answer inline.
+
+### OQ-1 — PR 4 material-edit detection for `In-scope files`
+
+The material-edit prompt fires when a save touches the `In-scope files` field of a signed plan. "Touches" is underspecified: does adding a file count? Removing one? Reordering? Renaming a path the linter reformatted? Each choice trades false-positive rate (annoying the user) against false-negative rate (a material change slips through unversioned).
+
+- **Proposal:** material change = the *set* of in-scope files changes (additions or removals). Pure reordering does not trigger. Path rename detected via git rename heuristics (or the user confirms on prompt) counts as set-preserving, not material. This keeps the prompt quiet on cosmetic edits while firing on the cases that matter for `gate_hash` (accepted RFC §6.5) consistency.
+- **Answer:** *(pending — resolve before PR 4 implementation)*
+
+Similar sub-questions for `In-scope functions`, `Out-of-scope`, and `Classification` may surface during implementation; resolve them with the same set-vs-ordering framing if they do.
+
 ## Pending discussions
 
 Directions that surfaced during design iteration and are worth resolving before or alongside implementation, but haven't been decided yet. Captured here so they aren't lost; each can fold into an existing PR, become a new PR, or defer to post-ship.
@@ -370,10 +394,12 @@ Directions that surfaced during design iteration and are worth resolving before 
 Offer named presets at Layer 0 question 5 so users with no opinion don't have to design a role vocabulary from scratch:
 
 - **Solo developer** — no sign-off roles required; skips Q5–Q8.
-- **Small team** — `approvals.roles: [product, tech_lead]`; sync mode `none`.
+- **Small team** — `approvals.roles: [product, qa]`; sync mode `none`.
 - **Open source** — `approvals.roles: [product, architecture]`; sync mode `central git repo` (per-team choice).
 - **Enterprise** — `approvals.roles` set to the full 9-role vocabulary from accepted RFC §6.4: `[security, product, compliance, sre, legal, privacy, architecture, qa, ba]`; sync mode `central git repo`.
 - **Custom** — free-form list (today's default).
+
+All four non-Custom presets use roles from the accepted RFC's suggested 9-role vocabulary (§6.4). The accepted RFC permits free-form role strings (§3.2) — teams that prefer labels like `tech_lead`, `reviewer`, or `maintainer` should pick **Custom**; the reconciler will still recognize them and warn only on typos, not on presence outside the suggested set.
 
 Each preset bundles matching `approvals.roles` and `approvals.share_path`/`approvals.git_repo` defaults. Would fold into §8 if accepted. Note: presets do not bundle per-role email assignments or signed-commit enforcement — both are deliberately out of scope per accepted RFC.
 

--- a/docs/rfcs/guided-entry-session-resume-multi-role.md
+++ b/docs/rfcs/guided-entry-session-resume-multi-role.md
@@ -405,7 +405,7 @@ Each preset bundles matching `approvals.roles` and `approvals.share_path`/`appro
 
 **Cognitive-load impact: high** — turns "design your role vocabulary" into "pick your situation."
 
-**Open coordination question:** this overlaps with the plan-phase scope-ingest discussion (see `docs/rfcs/notes/plan-phase-scope-ingest-discussion.md`) on whether "workflow templates" and "domain files" are the same artifact. Resolve before building either.
+**Resolved (2026-04-25): keep orthogonal.** Workflow presets (this section) configure sign-off mechanics — they are pure config bundled at `/configure` Q5. Domain files (`domains/payments.md` etc.) inject domain knowledge — they are pure content maintained by domain owners. The two serve different purposes and have different stewards. Advisory bridge: domain file schema gains optional `suggested_roles: []`; plan skill surfaces it at plan-time as context but does not enforce or override `approvals.roles`. Both can now build independently. Coordination gate lifted.
 
 ### B. Back/cancel navigation in interactive flows
 

--- a/docs/rfcs/guided-entry-session-resume-multi-role.md
+++ b/docs/rfcs/guided-entry-session-resume-multi-role.md
@@ -1,48 +1,55 @@
-# RFC: Guided Entry, Session Resume, and Multi-Role Approvals
+# RFC: Guided Entry, Session Resume, and Approval UX
 
-**Status:** Draft — **NEEDS RESHAPE before acceptance.** PRs 5 and 7 conflict with the already-accepted [multi-team-approval.md](./multi-team-approval.md) mechanism (which uses per-signer files under `.claude/sdlc/sign-offs/` + `## Required sign-offs` block in gate files + transport ladder; this RFC's PRs 5 and 7 propose an incompatible `approvals.chain` config + `@@SIGNATURE` blocks inside gate files + git-commits-per-signature). Path-A reshape (drop PRs 5 and 7, adjust PRs 3/6/8/9 to speak multi-team-approval's vocabulary) is pending — work continues next session.
+**Status:** Draft — reshaped against accepted [multi-team-approval.md](./multi-team-approval.md); ready for review.
 **Author:** Charlton Ho
 **Target:** `lantisprime/claude-sdlc`
 **Date:** 2026-04-20
+**Reshaped:** 2026-04-24
 
 ---
 
 ## Relationship to `multi-team-approval.md`
 
-The accepted `multi-team-approval.md` (2026-04-19) defines *how* cross-team sign-off works in this plugin: one file per signer under `.claude/sdlc/sign-offs/`, a `## Required sign-offs` block in each gate file, a reconciler hook, a transport ladder, and an `APPROVALS.md` git mirror. That mechanism is the authoritative design for multi-team approvals in this repo.
+The accepted `multi-team-approval.md` (2026-04-19) is the authoritative design for *how* cross-team sign-off works in this plugin: one file per signer under `.claude/sdlc/sign-offs/`, a `## Required sign-offs` block in each gate file, an `approval-reconcile.sh` hook, a transport ladder (Tier 0 local → Tier 1 network share → Tier 2 central git → Tier 3 deferred MCP), and a git-tracked `APPROVALS.md` projection.
 
-This RFC's *complementary* PRs layer on top of that mechanism without touching it:
-- PR 1 `/status`, PR 2 `/start`, PR 3 SessionStart hook, PR 4 plan versioning, PR 6 approval packet, PR 8 `/configure`, PR 9 glossary + `/help` + message library, PR 10 auto next-step hints.
+This RFC **layers UX surfaces on top of that mechanism.** It does not modify the sign-off contract, the transport ladder, the reconciler, `APPROVALS.md`, or the 9-role vocabulary. Where this RFC touches approvals, it references those constructs verbatim.
 
-This RFC's *conflicting* PRs need to be dropped or reshaped before acceptance:
-- PR 5 (multi-role approval chain) — proposes `approvals.chain` + `assignments` in `config/tools.json`. Conflicts with multi-team-approval's "`## Required sign-offs` in the gate file, roles declared per-gate" model. **Drop.** Any role-configuration work should extend `approvals.roles` as defined in multi-team-approval §6.4 instead.
-- PR 7 (distributed sign-off via git) — proposes `@@SIGNATURE` blocks inside gate files and commits-per-signature. Conflicts with multi-team-approval's "sign-off files are separate artifacts, one per signer, synced via transport ladder" model. **Drop.** Multi-team-approval's Tier 2 git-central-repo transport already provides distributed sign-off, differently.
+The eight PRs below are complementary to the accepted RFC:
 
-Path-A reshape (drop PRs 5 and 7, adjust vocabulary in the rest) is the path forward. This draft preserves today's brainstorming for tomorrow's session.
+- **PR 1** `/status` — read-only task state, renders sign-off progress for the active gate
+- **PR 2** `/start` — guided intake, front door for new users
+- **PR 3** SessionStart plan-check hook — surfaces in-flight work and unsigned roles
+- **PR 4** plan versioning and supersede
+- **PR 6** approval packet — derived artifact referenced by the `evidence:` field in sign-off files
+- **PR 8** `/configure` — guided configuration, scoped to what the user is actually doing
+- **PR 9** glossary + `/help` + shared message library
+- **PR 10** automatic next-step hints
+
+Two PRs from earlier draft iterations (in-session multi-role approval chain, distributed sign-off via git commits) were dropped during reshape because they duplicated or conflicted with the accepted RFC's model. See the PR 5 and PR 7 placeholders below for the reshape notes.
 
 ---
 
 ## Summary
 
-Add six small, independent improvements to the claude-sdlc plugin that reduce onboarding friction and support multi-team approval workflows, without modifying any of the plugin's load-bearing invariants.
+Add eight small, independent improvements to the claude-sdlc plugin that reduce onboarding friction and make the accepted multi-team-approval mechanism easier to live with day-to-day, without modifying any of the plugin's load-bearing invariants.
 
-The changes ship as six separate PRs, each scoped to one concern, each graceful-degrading, each optional by default so existing users see no behavior change until they opt in.
+Each change ships as a separate PR, scoped to one concern, graceful-degrading, optional by default so existing users see no behavior change until they opt in.
 
 ## Motivation
 
-Three concrete problems have surfaced in discussion and in principle, though not yet validated against real usage:
+Three concrete problems surfaced in discussion:
 
 1. **New users don't know where to start.** The plugin exposes eleven commands. A new user doesn't know which to run first, what information the system needs, or whether their task qualifies for `/fix-fast`. Today they either read the README carefully or run `/plan` with incomplete input.
 
 2. **Session resume is invisible.** On SessionStart, `env-detect.sh` reports integrations but not in-flight SDLC work. A user returning to a project with a half-drafted plan has no signal that one exists, and no prompt to continue or revise.
 
-3. **Single sign-off and single-machine sign-off don't scale to distributed contributors.** `gate-signoff` captures one human signature in one Claude Code session on one machine. Open-source contributors approving a plan from different continents, or even a small team with a tech lead in a different office, cannot both sign the same gate today without co-locating at one keyboard. Organizations with formal change control need tech-lead, architect, and approver sign-offs in sequence — typically across three different people on three different machines.
+3. **The accepted multi-team-approval mechanism is discoverable only on explicit inspection.** A returning approver has no pull-side signal that sign-off files are expected from them on the active branch. The mechanism works; the *surfacing* of pending work does not. Today a signer must read the gate file's `## Required sign-offs` block, diff it against `sign-offs/`, and notice their role is still open — or wait to be told. This RFC's PR 3 and PR 1 close that pull-side gap.
 
-A secondary motivation: after three rounds of design iteration on these problems, the work converged on changes that fit the repo's existing patterns rather than requiring new architecture. This RFC captures that convergence before implementation begins.
+A secondary motivation: after multiple rounds of design iteration, the work converged on changes that fit the repo's existing patterns rather than requiring new architecture. This RFC captures that convergence before implementation begins.
 
 ## Non-goals
 
-Explicitly not in scope, based on `CLAUDE.md`'s "Things NOT to change" section and prior design discussion:
+Explicitly not in scope, based on `CLAUDE.md`'s "Things NOT to change" section, the accepted multi-team-approval RFC, and prior design discussion:
 
 - Reordering or renaming the 8 phases
 - Adding a 4-phase user abstraction over the 8 internal phases
@@ -53,6 +60,7 @@ Explicitly not in scope, based on `CLAUDE.md`'s "Things NOT to change" section a
 - Building appeal paths, reviewer-of-reviewers, or retrospective audits
 - Rewriting hooks in Python or JavaScript
 - Bundling multiple changes per PR
+- **Modifying the accepted multi-team-approval sign-off contract, transport ladder, reconciler, `APPROVALS.md` generator, or 9-role set** — this RFC consumes those constructs; any change to them requires an amendment to that RFC
 - Auto-running `/configure` on anything other than first install (Layer 0) or explicit command-time need (Layer 2) — Layer 1 (partial/broken config) stays warn-only
 - Auto-writing config without an explicit diff confirmation — `/configure` always shows the proposed change before saving
 
@@ -62,11 +70,22 @@ Deferred work (appeal paths, audit retrospectives, sophisticated delegation) wil
 
 ### 1. `/status` command — read-only task state
 
-A new command that prints the current in-flight task: active phase, pending gate, blockers, next action. Reads `.claude/sdlc/env.json`, `gates/*.md`, and `plans/*.md`. Writes nothing.
+A new command that prints the current in-flight task: active phase, pending gate, blockers, next action, and **sign-off progress for the active gate.** Reads `.claude/sdlc/env.json`, `gates/*.md`, `plans/*.md`, and `.claude/sdlc/sign-offs/`. Writes nothing.
+
+**Sign-off progress render.** When an active gate has a `## Required sign-offs` block (per accepted RFC §3.2), `/status` renders one line showing which roles have landed files in `sign-offs/` and which haven't:
+
+```
+Plan: auth-refresh (signed)
+Gate: design-auth-refresh (awaiting sign-offs)
+Sign-offs: security ✓ | product ✓ | compliance □
+Next: await compliance, or /help sign-offs for the sign-off file format.
+```
+
+Symbols: `✓` file present in `sign-offs/<REQ-ID>-<role>.md`, `□` expected but absent. The render is **unordered** because the accepted RFC's model is parallel, not sequential — the row's order is the order the roles appear in the gate file's sign-offs block. If no gate is active or the gate has no sign-offs block, the line is omitted.
 
 **Files added:** `commands/status.md`, `skills/status/SKILL.md`
 **Files modified:** none
-**Rationale:** Attacks the "where am I, what's blocking me" cognitive load directly. Pure additive, zero regression risk.
+**Rationale:** Attacks the "where am I, what's blocking me" cognitive load directly. The sign-off render recovers most of the "chain visualization" affordance that dropped PRs 5 and 7 had provided, re-expressed honestly against the accepted RFC's unordered parallel model. Pure additive, zero regression risk.
 
 ### 2. `/start` command — guided intake
 
@@ -78,21 +97,25 @@ A thin wrapper over the existing `plan` skill. Asks the user: task type, UI impa
 
 ### 3. SessionStart plan check hook
 
-A new hook running alongside `env-detect.sh` on SessionStart. Scans `plans/` and `gates/` and prints one of:
+A new hook running alongside `env-detect.sh` on SessionStart. Scans `plans/`, `gates/`, and `.claude/sdlc/sign-offs/`, and prints one of:
 
 - **No active work** — nudges the user: "Run `/start` to begin."
 - **Drafted-but-unsigned plan** — offers resume or revise.
 - **Signed mid-phase task** — shows active phase and next action.
-- **Awaiting your signature on branch `<name>`** — fires when identity resolves via `git config user.email` or `CLAUDE_SDLC_APPROVER_IDENTITY`, `approvals.assignments` is configured (PR 5), and the resolved identity maps to an unsigned role on an active gate.
+- **Sign-offs pending on `<branch>`** — lists unsigned roles from the active gate's `## Required sign-offs` block. See sub-section below for partial personalization.
 - **Multiple active plans** — lists them.
 
 Writes nothing. Blocks nothing. Matches the existing `env-detect.sh` pattern.
 
-**Output budget (applies to all SessionStart hooks).** Each SessionStart hook is capped at roughly 5 lines of output by convention; anything longer is hidden behind an on-demand command (`/status` for task detail, `/configure --check` for config-validation detail once PR 8 lands). Goal: the first thing a returning user sees is scannable in under a second. This constraint applies to `env-detect.sh`, this hook, and any future SessionStart hook.
+**Partial personalization (opt-out).** The hook cross-references `git config user.email` against the `signer:` frontmatter of *previously-signed* sign-off files in the repo. If the returning user's email has historically signed as role X on past REQs, the hook assumes the same person is likely expected to sign as role X on the current REQ, and upgrades the line from *"Sign-offs pending: security, compliance"* to *"Likely awaiting your signature (security) — based on past sign-offs."*
+
+The heuristic is flagged honestly ("based on past sign-offs") and can be silenced per-repo via `display.session_signoff_hints: off` in `config/tools.json`. If no historical sign-off exists for that email, the hook degrades to the unpersonalized list. The plugin does not introduce a role-to-email map in config — the accepted RFC deliberately keeps identity in the sign-off file, not in config, and this RFC honors that.
+
+**Output budget (applies to all SessionStart hooks).** Each SessionStart hook is capped at roughly 5 lines of output by convention; anything longer is hidden behind an on-demand command (`/status` for task detail, `/configure --check` for config-validation detail once PR 8 lands). Goal: the first thing a returning user sees is scannable in under a second.
 
 **Files added:** `hooks/session-plan-check.sh`
 **Files modified:** `hooks/hooks.json`
-**Rationale:** Surfaces existing state so users can choose to continue, revise, or start new work. The "awaiting your signature" state is the pull-side complement to PR 5/7's push-side CLI output and tracker comments — catches approvers when they next open the repo without the plugin owning notification infrastructure. Warn-only, exit 0.
+**Rationale:** Surfaces existing state so users can choose to continue, revise, or start new work. The "sign-offs pending" state is the pull-side signal that the accepted multi-team-approval RFC deliberately leaves to UX layers — catching approvers when they next open the repo without the plugin owning notification infrastructure or introducing a role-to-email config. Warn-only, exit 0.
 
 ### 4. Plan versioning and supersede
 
@@ -117,6 +140,8 @@ stateDiagram-v2
 
 The "material edit" prompt fires only when a save touches Classification, In-scope files, In-scope functions, Out-of-scope, or the Risk-level field. All other edits — prose clarification, typo fixes, reformatting — pass silently. Visibility only, no enforcement.
 
+Versioning interaction with accepted RFC's `gate_hash` field: a material edit to a signed plan changes the gate file content, which changes the `gate_hash` computed at sign-off time. The reconciler already warns on hash mismatch per accepted RFC §6.5. Plan versioning makes the mismatch explicit in the artifact itself — prior sign-offs remain on the `v1` file, and the `v2` file accumulates its own sign-offs. Reconciler and version machinery agree on the outcome.
+
 **Soft handling to reduce friction.** Versioning adds concepts (version, supersede, material change) that didn't exist before. Three affordances keep them out of the user's way when possible:
 
 - **Hide version when v1 is the only version.** `/status` and other surfaces render `Plan: <slug>` with no version suffix until v2+ exists. One version costs zero UI.
@@ -127,92 +152,25 @@ The "material edit" prompt fires only when a save touches Classification, In-sco
 **Files modified:** `templates/plan.md`, `skills/plan/SKILL.md`, `hooks/plan-gate.sh`, `hooks/diff-scope-check.sh`, `docs/SDLC.md`
 **Rationale:** Closes the gap where the plan file itself is mutable after signing. Existing `change-request.md` covers scope changes via ceremony; versioning covers them via the artifact itself. Existing unversioned plans continue to work as `Version: 1` implicit.
 
-### 5. Multi-role approval chain
+### 5. [Dropped during reshape]
 
-Extends `gate-signoff` from single sign-off to a configurable approval chain. Adds an `approvals` block to `config/tools.example.json` (no new config file) with chain, assignments, timeout, fallback, and notify keys. Gate-signoff walks the chain in order, prompting each role with the existing URL-as-acknowledgment convention preserved per role.
-
-When the signer does not match the assigned user or group, sign-off fails with a clear message. When assignments are unresolvable (no git config, no env var, empty assignments), the check degrades to a warning and captures the signature with a `role_verified: false` flag rather than blocking. Rejection requires a free-text reason. Role overlap is allowed and logged, not blocked.
-
-The optional `notify.on_signature` key controls push-side notification when a role signs. Values: `"none"` (default, no behavior change) or `"comment_on_workitem"` (post a comment to the work item already linked in the plan, naming the role just signed and the next assignee). Uses the same work-item integration the plugin already relies on for traceability — no new dependency. If the tracker is unreachable, unconfigured, or authentication fails, the hook degrades to local print and records `notification_sent: false` in the signature block. This pairs with PR 3's SessionStart "awaiting your signature" state to give both push- and pull-side signals without the plugin owning notification infrastructure.
-
-**Chain visibility — one render across all surfaces.** When an approval chain exists, a single one-line render shows its state everywhere the chain is surfaced: `/status`, the SessionStart "awaiting your signature" output (PR 3), and tracker-comment notifications (the `notify` feature above). Format:
-
-```
-Chain: tech_lead ✓ alice  →  architect ⏳ bob (awaiting)  →  security □ carol
-```
-
-Symbols: `✓` signed, `⏳` awaiting current user or next assignee, `□` pending future approver. A shared helper in `skills/gate-signoff/` renders the line from gate-file state; all three surfaces consume the same helper so users learn one visual pattern, not three. Appears only when a chain is configured — single sign-off users see nothing new.
-
-If the `approvals` block is absent, behavior is exactly today's single sign-off.
-
-**Files added:** none
-**Files modified:** `config/tools.example.json`, `templates/gate.md`, `skills/gate-signoff/SKILL.md`, `hooks/phase-gate.sh`, `docs/SDLC.md`
-**Rationale:** Separates authority from visibility. Lets organizations declare their chain in config without touching code. Default-off means zero impact on current users.
+PR 5 (in-session multi-role approval chain, `approvals.chain` + `assignments` config) was dropped during reshape on 2026-04-24. Multi-role approval is the scope of accepted [multi-team-approval.md](./multi-team-approval.md) — see §3.1 (sign-off file contract), §3.2 (gate-file `## Required sign-offs` block), §3.3 (reconciler hook), and §6.4 (role vocabulary). This RFC does not introduce a parallel chain mechanism; PR 1's `/status` render and PR 3's SessionStart hook surface the accepted model instead.
 
 ### 6. Approval packet
 
-A derived artifact compiled at sign-off time containing scope, delta from previous approved version, risk level and justification, mitigation and rollback plan, traceability links, decision required, and reason for approval request. Includes a header disclaimer reminding reviewers the packet is a summary and source artifacts remain authoritative. Every section links to its source, not just references it.
+A derived artifact compiled at sign-off time containing scope, delta from previous approved version, risk level and justification, mitigation and rollback plan, traceability links, decision required, and reason for approval request. Includes a header disclaimer reminding reviewers the packet is a summary and source artifacts remain authoritative. Every section links to its source.
+
+**Integration with accepted RFC's `evidence:` field.** A sign-off file's `evidence:` field (accepted RFC §3.1) names an artifact that substantiates the sign-off. The packet is designed to be a natural target: a reviewer opens the packet, reads the summary with source links, then writes their sign-off file with `evidence: .claude/sdlc/approval-packets/REQ-042-v2.md`. The packet complements the accepted RFC's §6.6 **evidence quality ladder** (*prefer* git SHA, PDF path with sha256, signed commit; *avoid* editable wiki pages, Slack message links) — a packet in the repo, referenced by relative path, sits at the "prefer" end of that ladder.
 
 If the compiled packet exceeds roughly two screens (around 100 lines), the skill prompts the author to summarize further. Warning, not block.
 
 **Files added:** `templates/approval-packet.md`
 **Files modified:** `skills/gate-signoff/SKILL.md`, `docs/SDLC.md`
-**Rationale:** Reviewers today must stitch together four or more files to understand what they're signing. The packet is a compile step, not new information.
+**Rationale:** Reviewers today must stitch together four or more files to understand what they're signing. The packet is a compile step, not new information. Packet-as-evidence gives the accepted RFC's `evidence:` field a canonical, high-quality default.
 
-### 7. Distributed sign-off via git
+### 7. [Dropped during reshape]
 
-Makes `gate-signoff` resumable across machines so each role in the approval chain can sign from their own environment. Each signature becomes its own commit; the gate file is a collaboratively-edited artifact rather than a single-session output.
-
-When `gate-signoff` runs, it reads the existing gate file and detects which signatures are already present. It prompts only for the next missing role in the chain. It writes just that signature block and does not overwrite prior signatures. The approver commits and pushes; the next approver in the chain pulls the branch, runs `gate-signoff`, and signs their block.
-
-```mermaid
-sequenceDiagram
-    actor A as Approver A (tech_lead)
-    actor B as Approver B (architect)
-    participant Gate as gate/<slug>.md
-    participant Local as Local git
-    participant Remote as Git remote
-
-    A->>Local: gate-signoff
-    Local->>Local: Resolve identity<br/>(git config user.email)
-    Local->>Local: Match to 'tech_lead' in assignments
-    Local->>Gate: Write tech_lead signature block
-    Local-->>A: Commit this signature? [Y/n]
-    A->>Local: Y
-    Local->>Local: git commit (role_verified=true)
-    Local->>Remote: git push
-    Local-->>A: "Next approver: architect — bob@acme.com"
-
-    B->>Remote: git pull <branch>
-    Remote-->>B: Branch with tech_lead signature
-    B->>Local: gate-signoff
-    Local->>Gate: Detect existing tech_lead block, skip
-    Local->>Local: Resolve identity → match 'architect'
-    Local->>Gate: Append architect signature block
-    Local->>Local: git commit + push
-    Local-->>B: "All roles signed. Gate complete."
-```
-
-Role identity is resolved from `git config user.email` as the primary source, with `CLAUDE_SDLC_APPROVER_IDENTITY` as an override for environments where git config is unavailable. The resolved identity is matched against the `assignments` map from PR 5.
-
-The commit containing each signature becomes part of the audit trail. Git authorship, timestamp, and optionally GPG signing (`git commit -S`) layer on top of the URL-as-acknowledgment convention. The gate file itself continues to quote each human's raw URL acknowledgment verbatim.
-
-Optional: the hook or skill can prompt "Commit this signature now? [Y/n]" after writing, making the git flow explicit to users who may not realize the sign-off needs to land in a commit.
-
-**Graceful degradation — summary.** PR 7 has more failure modes than PR 5 and treats each according to intent. The plugin degrades, hands off, or refuses depending on which layer is missing. The short version:
-
-- **Not in a git repo** → hand off to PR 5 in-session multi-role
-- **Identity unresolvable and `assignments` absent** → capture signature with `role_verified: false`
-- **Identity unresolvable but `assignments` configured** → *refuse*, with a clear message (intentional, not a gap)
-- **Identity resolved but mismatches assignment** → *refuse* (intentional)
-- **No remote or push rejected** → local commit stands, print next-step guidance
-- **`commit -S` requested but signing key missing** → sign unsigned, flag `commit_signed: false`
-
-The full decision tree, including test cases and interaction with branch protection, lives in the implementation note at `docs/rfcs/notes/guided-entry-pr7-degradation.md` (added alongside the RFC). Implementers should read the note before writing the skill changes. **Note:** this whole PR is marked for drop in the reshape pass — see the "Relationship to multi-team-approval.md" section.
-
-**Files added:** `docs/rfcs/notes/0001-pr7-degradation.md` (implementation note)
-**Files modified:** `skills/gate-signoff/SKILL.md`, `templates/gate.md` (structure for multiple independent signature blocks), `docs/SDLC.md`
-**Rationale:** The existing sign-off model assumes one human at one keyboard. Contributors to an open-source repo, or distributed teams, cannot both sign the same gate without co-locating. Git is already the repo's state store, branches are already the coordination mechanism, PRs are already how changes cross machines — treating gate files as commit-by-commit artifacts uses infrastructure already present. No new services, no new protocols. Preserves all invariants: still human-in-the-lead, still URL-acknowledged, still fresh per role, with an explicit degradation matrix rather than the single-line fallback PR 5 could offer.
+PR 7 (distributed sign-off via commits-per-signature, `@@SIGNATURE` gate-file blocks, `CLAUDE_SDLC_APPROVER_IDENTITY` env var) was dropped during reshape on 2026-04-24. The accepted [multi-team-approval.md](./multi-team-approval.md) handles distributed sign-off via **file transports** rather than commits-as-signatures: §3.4 Tier 2 moves sign-off files through a central git repo, §3.5 projects them into a git-tracked `APPROVALS.md`. Identity lives in the `signer:` field of each sign-off file (accepted RFC §3.6), not in a config map or env var. PR 7's companion note is preserved at `docs/rfcs/notes/guided-entry-pr7-degradation.md` with status `superseded` for historical reference.
 
 ### 8. Guided configuration (`/configure`)
 
@@ -250,7 +208,7 @@ config_requirements:
 
 Layer 2 reads this block to decide what to pass to `/configure --needs` and how to handle cancel. Keeps the auto-invoke logic declarative — no per-command branching.
 
-**Public vs. local config.** Non-secret keys (chain, assignments, notify preference, tracker.type, tracker.project) go to `config/tools.json` (version-controlled). Auth tokens and anything secret go to `config/tools.local.json`. `/configure` adds `config/tools.local.json` to `.gitignore` on first write if not already present. Always shows a diff of the proposed change before saving — never writes without explicit confirmation.
+**Public vs. local config.** Non-secret keys (`approvals.roles`, `approvals.share_path`, `approvals.git_repo`, `tracker.type`, `tracker.project`) go to `config/tools.json` (version-controlled). Auth tokens and anything secret go to `config/tools.local.json`. `/configure` adds `config/tools.local.json` to `.gitignore` on first write if not already present. Always shows a diff of the proposed change before saving — never writes without explicit confirmation.
 
 **Dry-run.** `/configure --check` parses current config, runs the validation pass, prints what would be asked. No prompts, no writes. Mirrors `/status`'s read-only posture.
 
@@ -259,39 +217,50 @@ Layer 2 reads this block to decide what to pass to `/configure --needs` and how 
 1. Tracker type? (Linear / GitHub Issues / Jira / none)
 2. Tracker auth token? (only if tracker chosen; stored in `tools.local.json`)
 3. Tracker project key or repo? (only if tracker chosen)
-4. Will this project need multi-person sign-off? (Y/n) — **if `n`, skip questions 5–8 entirely and finish**
-5. Which roles in the chain? (comma-separated; default: `tech_lead, approver`)
-6. Email/identity for each role? (one prompt per role; `git config user.email` pre-filled as default for the first unassigned slot)
-7. Notify on signature? (none / comment on work item)
-8. Require signed commits (GPG/SSH) for sign-off? (default: no)
+4. Will this project use multi-team sign-off? (Y/n) — **if `n`, skip questions 5–7 and finish**
+5. Role vocabulary? (suggested 9-role set from accepted RFC §6.4 / custom comma-separated list) — writes `approvals.roles`
+6. Sync sign-off files across machines? (none / network share / central git repo / defer)
+7. (Conditional on Q6) Share path or central git repo URL? — writes `approvals.share_path` or `approvals.git_repo`
+8. Enable `display.session_signoff_hints` personalization in PR 3? (Y/n; default Y)
 
-Single sign-off users answer 3 questions and finish. Multi-role users answer up to 8. No question presents a free-text field without a sensible default offered where possible. The budget is a ceiling, not a target — adding a 9th question requires justifying why it can't be deferred to a later reconfigure flow.
+Single sign-off users answer 3 questions and finish. Multi-team users answer up to 8. No question presents a free-text field without a sensible default offered where possible. The budget is a ceiling, not a target — adding a 9th question requires justifying why it can't be deferred to a later reconfigure flow.
+
+**Deliberately excluded from Q5–Q8:** per-role email assignments (accepted RFC keeps signer identity in the sign-off file, not in config), signed-commit enforcement (accepted RFC §3.9 treats cryptographic attestation as a team-workflow concern outside the plugin), and tracker-notification-on-signature (not in accepted RFC scope; would need its own mini-RFC to land).
 
 **Context-aware defaults.** `/configure` inspects the environment before prompting and pre-selects likely answers: `.github/` directory → suggest GitHub Issues; `.linear.yml` or the Linear CLI on PATH → suggest Linear; `git remote -v` containing `github.com` → suggest GitHub Issues as the secondary default. User can always override; the point is to make the default the user's probable answer so accept-and-continue is a single keystroke.
 
-**Rationale.** `/configure` is the largest single cognitive-load win in this RFC. Current users must read `config/tools.example.json`, infer the schema, and know which fields are secret. `/configure` asks plain-language questions, validates as it goes, handles the public/local split automatically, and — because Layers 0 and 2 auto-invoke — removes the need to memorize the command at all.
+**Rationale.** `/configure` is the largest single cognitive-load win in this RFC. Current users must read `config/tools.example.json`, infer the schema, and know which fields are secret. `/configure` asks plain-language questions, validates as it goes, handles the public/local split automatically, and — because Layers 0 and 2 auto-invoke — removes the need to memorize the command at all. After reshape, the question bank is *smaller* than the pre-reshape draft (per-role assignments and signed-commit enforcement dropped out), so onboarding is faster, not slower.
 
 ### 9. Glossary, `/help`, and shared message library
 
 Three user-facing-text assets that ship together because they share the same audience (anyone reading plugin output) and the same failure mode (inconsistent wording confuses users). Bundling keeps the vocabulary, the lookup, and the message phrasing coordinated.
 
-**Glossary.** Adds `docs/GLOSSARY.md` defining the vocabulary this RFC introduces (plan version, supersede, material change, approval chain, role, assignment, approver, packet, `role_verified`, `commit_signed`, `notification_sent`, `config_requirements`, Layer 0–3) and the pre-existing terms the RFC builds on (plan, gate, sign-off, phase, in-scope/out-of-scope, change-request). Each entry: one-sentence definition, one-sentence context, link to the section where it's used.
+**Glossary.** Adds `docs/GLOSSARY.md` defining the vocabulary this RFC introduces and the accepted-RFC vocabulary it consumes.
+
+RFC-introduced terms: *plan version*, *supersede*, *material change*, *approval packet*, *config requirements*, *Layer 0–3*, *session sign-off hint*.
+
+Accepted-RFC terms this RFC consumes (referenced, not redefined): *sign-off file*, *gate_hash*, *`APPROVALS.md`*, *reconciler*, *transport ladder*, *Tier 0–3*, *role vocabulary*, *evidence field*, *evidence quality ladder*.
+
+Each entry: one-sentence definition, one-sentence context, link to the section or RFC where it's defined. Accepted-RFC terms link to `multi-team-approval.md` directly so the glossary doesn't become a second source of truth.
+
+**Callout: sign-offs are unordered parallel.** A dedicated glossary paragraph (and a one-paragraph note in `/help sign-offs`) explicitly teaches that the accepted multi-team-approval model is parallel, not sequential. No signer waits for another; any ordering seen in output is presentation-only. This prevents users migrating from single-signer or chain-style mental models from assuming an ordering that doesn't exist and getting confused when a "later" role signs before an "earlier" one.
 
 **`/help` command.** Bridges vocabulary, commands, and current state into one "I'm confused" destination:
 
 - `/help` (no arguments) — prints (1) current SDLC state (mirror of `/status` output), (2) the command table with one-line descriptions, (3) the five most-relevant glossary terms for the current state. Three-section layout, clearly delimited, budgeted to fit in one screen.
 - `/help <term>` — prints just the matching glossary entry.
 - `/help <command>` — prints the command's purpose, arguments, and a usage example.
+- `/help sign-offs` — prints the unordered-parallel callout, the sign-off file format, and a pointer to accepted-RFC §3.1.
 
 Showing state alongside vocabulary means a confused user doesn't have to guess whether to run `/status` or `/help` — the bridge-command handles the overlap and points them at the narrower commands when they know what they need.
 
-**Shared message library.** Adds `skills/_shared/messages/` — a catalog of reusable user-facing strings keyed by event ID. Every skill that prints a refuse, degrade, handoff, or warn message reads from the catalog rather than hardcoding text. Examples: `identity_unresolvable_with_assignments`, `tracker_notification_failed`, `config_unparseable`, `chain_role_already_signed`.
+**Shared message library.** Adds `skills/_shared/messages/` — a catalog of reusable user-facing strings keyed by event ID. Every skill that prints a refuse, degrade, handoff, or warn message reads from the catalog rather than hardcoding text. Examples relevant to the reshaped PR set: `config_unparseable`, `gate_hash_mismatch`, `signoff_file_malformed`, `transport_unreachable`, `session_signoff_hint_personalized`, `session_signoff_hint_unpersonalized`.
 
-Benefits: (1) wording stays consistent across commands — "identity unresolvable" reads identically whether it's printed from `gate-signoff`, `/configure`, or `/status`; (2) translation/rewording is one file, not a grep across every skill; (3) the `/help` glossary can cross-link to the messages that use each term.
+Benefits: (1) wording stays consistent across commands; (2) translation/rewording is one file, not a grep across every skill; (3) the `/help` glossary can cross-link to the messages that use each term.
 
 **Files added:** `docs/GLOSSARY.md`, `commands/help.md`, `skills/help/SKILL.md`, `skills/_shared/messages/` (catalog files, one per event category)
 **Files modified:** `README.md` (point at GLOSSARY for term lookup), every skill that prints refuse/degrade/handoff/warn messages (reads from the message catalog instead of hardcoding)
-**Rationale:** This RFC introduces roughly ten new nouns on top of existing vocabulary and many new failure-mode messages. Forcing users to grep docs to recover a definition, or forcing wording to drift across three skills that all say "identity unresolvable" slightly differently, are both avoidable frictions. Bundling the glossary, the `/help` bridge, and the shared message catalog keeps the user-facing text layer coherent. Ships after PR 5 so the full new vocabulary and the full new set of messages exist when the catalog is first populated.
+**Rationale:** This RFC adds new vocabulary on top of the accepted RFC's vocabulary, and introduces new failure-mode messages. Forcing users to grep docs for definitions, or letting wording drift across skills, are both avoidable frictions. The unordered-parallel callout in particular prevents a common mental-model error that would otherwise keep biting users long after the RFC ships. Ships after PR 8 so the full configuration surface exists when the catalog is first populated.
 
 ### 10. Automatic next-step hints
 
@@ -299,23 +268,24 @@ Every user-visible command appends a single "Next:" line at the end of its outpu
 
 Examples:
 
-- `/plan` completes with an unsigned plan → `Next: /status to review, or /gate-signoff when ready.`
-- `/gate-signoff` completes with chain fully signed → `Next: begin analyze phase.`
+- `/plan` completes with an unsigned plan → `Next: /status to review, or write your sign-off file at sign-offs/<REQ-ID>-<role>.md when ready.`
+- Sign-off file lands and all required roles are covered → `Next: begin analyze phase.`
 - `/configure` completes via Layer 2 auto-invoke → *no "Next:" printed — the resumed command IS the next step.*
 - `/status` with no active work → `Next: /start to begin a new task.`
-- `/status` with a signed mid-phase task → `Next: continue with <phase> commands, or /gate-signoff to approve.`
+- `/status` with a signed mid-phase task → `Next: continue with <phase> commands, or sign the phase gate when ready.`
+- `/status` with pending sign-offs and user matches a likely role → `Next: write your sign-off at sign-offs/<REQ-ID>-<role>.md.`
 
 **Declarative per-skill.** Each skill's SKILL.md gains a `next_suggestions` frontmatter block. The suggestion is chosen by matching the `when` condition against current state:
 
 ```yaml
 next_suggestions:
   - when: plan_drafted_and_unsigned
-    suggest: "/status to review, or /gate-signoff when ready"
+    suggest: "/status to review, or write your sign-off file at sign-offs/<REQ-ID>-<role>.md when ready"
   - when: plan_signed_and_no_phase_active
     suggest: "begin analyze phase"
 ```
 
-A shared helper at `skills/_shared/next-hint.sh` resolves `when` conditions against `.claude/sdlc/env.json`, `gates/*.md`, and `plans/*.md` state, and prints the first matching `suggest`. If no condition matches, no "Next:" line is printed — silence is better than a wrong hint.
+A shared helper at `skills/_shared/next-hint.sh` resolves `when` conditions against `.claude/sdlc/env.json`, `gates/*.md`, `plans/*.md`, and `sign-offs/*.md` state, and prints the first matching `suggest`. If no condition matches, no "Next:" line is printed — silence is better than a wrong hint.
 
 **Suppression — three honest signals, no guessing at "is this a power user."**
 
@@ -333,34 +303,32 @@ Combined, these mean: scripts never see hints; new users see them until they int
 ## Dependency graph and ship order
 
 ```
-PR 1 (status)             — independent
+PR 1 (status)             — independent; renders accepted-RFC sign-off state
 PR 2 (/start)             — independent
 PR 3 (session check)      — independent; interim caveat points users at PR 4
 PR 4 (versioning)         — independent; strengthens PR 3's revise path
-PR 8 (/configure)         — independent; retroactively reduces setup friction for PR 1–4, unlocks PR 5
-PR 5 (multi-role chain)   — much easier to adopt after PR 8
-PR 9 (glossary + /help)   — best after PR 5 (full new vocabulary has landed)
-PR 7 (distributed signoff) — depends on PR 5 (reads the chain and assignments)
-PR 6 (approval packet)    — best after PR 4 and PR 5
-PR 10 (auto next-step hints) — ships last; applied uniformly across every skill once their outputs are stable
+PR 8 (/configure)         — independent; retroactively reduces setup friction for PR 1–4
+PR 9 (glossary + /help)   — best after PR 8 (full new vocabulary has landed)
+PR 6 (approval packet)    — best after PR 4 (version-aware delta) and PR 9 (glossary link target)
+PR 10 (auto next-step hints) — ships last; applied uniformly across every skill once outputs are stable
 ```
 
-**Ship order:** 1 → 2 → 3 → 4 → 8 → 5 → 9 → 7 → 6 → 10
+**Ship order:** 1 → 2 → 3 → 4 → 8 → 9 → 6 → 10
 
-PR 3 ships before PR 4 because session-resume is the fastest-visible cognitive-load win. Until PR 4 lands, PR 3's "drafted-but-unsigned" and "signed mid-phase" outputs include a short caveat: "revising a signed plan currently mutates it in place; versioning ships in PR 4." PR 8 lands immediately before PR 5 because the configuration surface jumps significantly at PR 5 — without `/configure`, teams would have to hand-edit JSON to adopt multi-role approval, which is exactly the friction this RFC is trying to remove. PR 8 also retroactively improves onboarding for PRs 1–4 (tracker config for `/plan`, etc.) by providing a guided path to whatever config they need. PR 9 lands after PR 5 so the glossary is written once against the full new vocabulary, not grown piecemeal. PR 7 lands immediately after PR 5 because multi-role in a single session is a half-feature for this repo's primary audience — open-source contributors who do not share a keyboard. PR 6 ships after PR 7 so the packet's signature section reflects the final shape of PR 5 + PR 7 together. PR 10 is last because it's a cross-cutting output convention — applying it to every skill is cleanest when each skill has settled into its final output shape.
+PR 3 ships before PR 4 because session-resume is the fastest-visible cognitive-load win. Until PR 4 lands, PR 3's "drafted-but-unsigned" and "signed mid-phase" outputs include a short caveat: "revising a signed plan currently mutates it in place; versioning ships in PR 4." PR 8 lands immediately before PR 9 because the configuration surface introduces `approvals.roles` + transport config, and the glossary is cleaner if written against a stable config surface. PR 9 lands after PR 8 so the glossary is written once against the full new vocabulary, not grown piecemeal. PR 6 lands after PR 4 so the packet's delta section knows the version shape, and after PR 9 so glossary cross-links work. PR 10 is last because it's a cross-cutting output convention — applying it to every skill is cleanest when each skill has settled into its final output shape.
 
-**Estimated effort:** roughly one to two weeks of focused work for one engineer, or two to three weeks calendar with testing, documentation, and iterating on skill descriptions until they trigger reliably.
+**Estimated effort:** roughly one week of focused work for one engineer, or one-and-a-half to two weeks calendar with testing, documentation, and iterating on skill descriptions until they trigger reliably. (Reduced from pre-reshape estimate because PRs 5 and 7 represented roughly one-third of the original scope.)
 
 ## Alignment with design principles
 
 | Principle | How this RFC preserves it |
 |---|---|
-| Human in the lead | No PR adds auto-approve. Every gate still needs fresh URL-acknowledged sign-off. PR 5 and PR 7 together add more humans across more machines, not fewer. |
-| Plan before code | No PR loosens `plan-gate.sh`. PR 4 strengthens it — versioning invalidates stale gates. |
+| Human in the lead | No PR adds auto-approve. Every sign-off still needs a human authoring a sign-off file per accepted RFC §3.1. PR 3's partial personalization is a *hint*, not a binding claim, and is opt-out. |
+| Plan before code | No PR loosens `plan-gate.sh`. PR 4 strengthens it — versioning invalidates stale gates; accepted RFC's `gate_hash` warns on post-sign edits. |
 | Surgical edits | Each PR is one concern. No PR spans unrelated skills or hooks. |
-| Work-item traceability | No PR adds a bypass. PR 6 makes traceability more visible via the packet; PR 7 makes each signature a git commit, strengthening the audit trail. |
-| Graceful degradation | Every new config key is optional. Missing `approvals` block means current behavior. Missing git config in PR 7 degrades to same-session multi-role from PR 5. |
-| Stack-agnostic | No hardcoded tool names. All new hooks use POSIX bash. No new runtime dependencies. PR 7 uses only `git`, already a hard dependency. |
+| Work-item traceability | No PR adds a bypass. PR 6 makes traceability more visible via the packet and gives the accepted RFC's `evidence:` field a canonical target. |
+| Graceful degradation | Every new config key is optional. Missing `approvals` block means current behavior. PR 3's personalization degrades cleanly to the unpersonalized list when no historical sign-off exists for the user's email. |
+| Stack-agnostic | No hardcoded tool names. All new hooks use POSIX bash. No new runtime dependencies. |
 
 ## What we will measure
 
@@ -369,39 +337,29 @@ Following the existing `token-tracker.sh` pattern: append JSONL lines to a histo
 - Time from `/start` to signed plan gate
 - Number of intake iterations before plan submission
 - Number of plan versions per task (PR 4 onward)
-- Approval cycle time per role (PR 5 onward)
 - Packet length per task (PR 6 onward)
 - `/configure` invocation source: Layer 0 auto-launch, Layer 2 resume, or manual (PR 8 onward)
 - `/help <term>` lookups by term — which vocabulary confuses users most (PR 9 onward)
 - Next-hint accept rate: did the user's next command match the suggested "Next:" line (PR 10 onward)
+- Session sign-off hint fire rate and personalization hit rate (PR 3 onward) — how often does the hint trigger, and how often does the historical heuristic produce a personalized line vs. fall back
 
 Metrics describe reality. They do not predict it. No improvement percentages are committed in this RFC — baseline first, interpret later.
 
 ## Alternatives considered
 
-**A rewrite with new architecture.** Three design iterations proposed new directory hierarchies (`.claude/sdlc/tasks/<task-id>/`), a new config file (`approval_config.json`), a new state machine, and commands prefixed `/sdlc:*`. Rejected because the repo already implements most of this via `plans/<slug>.md`, `config/tools.json`, gate files, and the existing command set. Building parallel structure would duplicate rather than improve.
+**A rewrite with new architecture.** Three design iterations proposed new directory hierarchies (`.claude/sdlc/tasks/<task-id>/`), a new config file (`approval_config.json`), a new state machine, and commands prefixed `/sdlc:*`. Rejected because the repo already implements most of this via `plans/<slug>.md`, `config/tools.json`, gate files, the accepted RFC's `sign-offs/` directory, and the existing command set. Building parallel structure would duplicate rather than improve.
 
 **A 4-phase user abstraction over the 8 internal phases.** Considered in two design rounds. Rejected because exposing both creates a dual vocabulary users must reconcile against error messages, logs, and hooks that speak the 8-phase language. One surface vocabulary is less cognitive load than two.
 
 **Auto-classified risk from LOC and file count.** Considered in design v2. Rejected because LOC thresholds create an illusion of determinism that doesn't hold — a 50-line change to rate-limiting logic is not the same risk as a 50-line rename. Declared judgment with required justification is the honest alternative.
 
-**A forced "reviewer must confirm traceability" checkbox at sign-off.** Considered and rejected. A forced checkbox is friction without function; reviewers who would skip traceability will click the box, reviewers who check it already do so. PR 6's source-link requirement is the nudge; the URL-as-acknowledgment convention is the non-trivial ack.
+**A forced "reviewer must confirm traceability" checkbox at sign-off.** Considered and rejected. A forced checkbox is friction without function; reviewers who would skip traceability will click the box, reviewers who check it already do so. PR 6's source-link requirement is the nudge; the accepted RFC's `evidence:` field is the non-trivial ack.
+
+**A role-to-email map in config (for PR 3 personalization).** Considered during reshape. Rejected because the accepted multi-team-approval RFC deliberately keeps identity in the sign-off file, not in config, to avoid stale config and to preserve the "signer is self-asserted" threat model (§3.6, §3.9). PR 3's historical heuristic recovers most of the UX value without opening that door.
+
+**An in-session chain render for PR 1.** The dropped PR 5 proposed an ordered chain (`tech_lead ✓ → architect ⏳ → security □`). Rejected at reshape because the accepted RFC's model is parallel, not sequential — a chain render would misrepresent the mechanism. PR 1's unordered pipe-separated render (`security ✓ | product ✓ | compliance □`) is the honest equivalent.
 
 **Appeal paths, reviewer-of-reviewers, sophisticated delegation.** Deferred. Real usage will generate specific requirements; pre-building governance for abuse cases that may not occur is how systems become unusable.
-
-**A centralized sign-off service or external API for PR 7.** Considered and rejected. Would introduce a network dependency, require hosting, and create a second source of truth competing with the repo. Git commits already give cryptographic authorship, ordered history, and a shared transport — no service needed. Teams that want cryptographic strength beyond commit authorship can opt into `git commit -S` without the plugin knowing or caring.
-
-## Open questions
-
-1. **"Unresolvable assignments" definition in PR 5.** Four cases: no git config, no env var, `assignments` key absent, `assignments` key present but empty. Default proposal: all four degrade to warning-plus-flag. Worth confirming before implementation.
-
-2. **Packet length threshold.** Two screens, roughly 100 lines, is a soft target. The actual number should come from observing real packets in dogfooding rather than committing now.
-
-3. **PR 7 commit flow.** Should `gate-signoff` commit the signature automatically, or prompt the user to commit? Auto-commit is cleaner UX but couples the plugin to a git write. Prompting preserves the "plugin proposes, human acts" posture. Default proposal: prompt, with a config flag to auto-commit for teams that want it.
-
-4. **PR 7 and branch protection.** If the repo has branch protection rules requiring PR review, the signature commits may need to land on a feature branch rather than directly on main. The plugin should not mandate a workflow — it writes the commit; how it's merged is the team's concern.
-
-5. **PR 7 identity spoofing risk.** `git config user.email` is trivially changeable. A malicious contributor could set it to impersonate an approver. Mitigation options: (a) accept the risk — existing sign-off has the same property, just more tightly bound to one session; (b) enable branch protection with required PR review so signature commits cannot land on a protected branch without a second human approving the merge — the pragmatic baseline; (c) opt into `git commit -S` with GPG or SSH verification against a published keyring for cryptographic authorship; (d) defer stronger identity to a future PR. Default proposal: (a) for now, document the risk clearly, recommend (b) for teams that want a mitigation today, allow teams to opt into (c).
 
 ## Pending discussions
 
@@ -409,19 +367,23 @@ Directions that surfaced during design iteration and are worth resolving before 
 
 ### A. Workflow templates in `/configure`
 
-Offer named presets at Layer 0 question 5 so users with no opinion don't have to design a chain from scratch:
+Offer named presets at Layer 0 question 5 so users with no opinion don't have to design a role vocabulary from scratch:
 
-- **Solo developer** — no chain, just self sign-off; skips questions 5–8.
-- **Small team** — `tech_lead, approver`; notify = `none`; auto_commit = `false`.
-- **Open source** — `maintainer, approver`; notify = `comment_on_workitem`; distributed sign-off (PR 7) enabled.
-- **Enterprise** — `tech_lead, architect, security, approver`; notify = `comment_on_workitem`; require_signed_commits = `true`.
+- **Solo developer** — no sign-off roles required; skips Q5–Q8.
+- **Small team** — `approvals.roles: [product, tech_lead]`; sync mode `none`.
+- **Open source** — `approvals.roles: [product, architecture]`; sync mode `central git repo` (per-team choice).
+- **Enterprise** — `approvals.roles` set to the full 9-role vocabulary from accepted RFC §6.4: `[security, product, compliance, sre, legal, privacy, architecture, qa, ba]`; sync mode `central git repo`.
 - **Custom** — free-form list (today's default).
 
-Each preset bundles matching notify/auto_commit/require_signed_commits defaults. Would fold into §8 if accepted. **Cognitive-load impact: high** — turns "design your approval workflow" into "pick your situation."
+Each preset bundles matching `approvals.roles` and `approvals.share_path`/`approvals.git_repo` defaults. Would fold into §8 if accepted. Note: presets do not bundle per-role email assignments or signed-commit enforcement — both are deliberately out of scope per accepted RFC.
+
+**Cognitive-load impact: high** — turns "design your role vocabulary" into "pick your situation."
+
+**Open coordination question:** this overlaps with the plan-phase scope-ingest discussion (see `docs/rfcs/notes/plan-phase-scope-ingest-discussion.md`) on whether "workflow templates" and "domain files" are the same artifact. Resolve before building either.
 
 ### B. Back/cancel navigation in interactive flows
 
-Every interactive prompt across `/configure`, `/start`, and `gate-signoff` supports:
+Every interactive prompt across `/configure`, `/start`, and sign-off-file authoring supports:
 
 - `b` — back to the previous question (answers already given are preserved as defaults)
 - `?` — contextual help for the current prompt
@@ -431,11 +393,11 @@ Implemented once in `skills/_shared/prompt.sh` and consumed by every skill that 
 
 ### C. Error-message audit to the three-part template
 
-Once PR 9's shared message library exists, every user-facing error and warning in the plugin gets audited and rewritten to match the three-part template PR 7's refusal messages already follow:
+Once PR 9's shared message library exists, every user-facing error and warning in the plugin gets audited and rewritten to match a three-part template:
 
-1. **What happened** ("Identity unresolvable for role 'architect'")
-2. **Why** ("no git config user.email, no CLAUDE_SDLC_APPROVER_IDENTITY set")
-3. **What to do** ("Run `/configure --needs assignments.architect`, or set git config")
+1. **What happened** ("Sign-off file `sign-offs/REQ-042-security.md` has malformed frontmatter")
+2. **Why** ("missing required field `gate_hash`")
+3. **What to do** ("re-author via the sign-off template, or run `/help sign-offs` to see the format")
 
 Mechanical once the catalog exists. Could be part of PR 9 scope or ship as a PR 9-follow-on. **Cognitive-load impact: medium-high** — failure moments are peak anxiety; consistent message shape collapses the panic-to-fix cycle.
 
@@ -456,27 +418,30 @@ Phase 3 of 8 — analyze
   [ ] Identify out-of-scope files
   [ ] Confirm risk level
   [ ] Document assumptions
-Next: continue analyze, or /gate-signoff when complete.
+Next: continue analyze, or write sign-off files when complete.
 ```
 
 Turns opaque "mid-phase" into concrete progress. Would expand §1's `/status` spec if accepted. **Cognitive-load impact: medium.**
 
 ## Security and privacy considerations
 
-No new external services. No new network calls. No new secrets handling beyond what the plugin already does. All state remains local to `.claude/sdlc/` and to the repo's git history. Role assignments in `config/tools.json` are user-visible and version-controlled; teams concerned about role information in repo history should place assignments in a `tools.local.json` added to `.gitignore`.
+No new external services. No new network calls. No new secrets handling beyond what the plugin already does. All state remains local to `.claude/sdlc/` and to the repo's git history.
 
-**PR 7 specifically.** Identity for sign-off derives from `git config user.email`, which any contributor can set. This is the same trust model the repo already uses for commit authorship — anyone can author a commit as anyone. Teams that need stronger guarantees should (a) enable branch protection so signature commits go through PR review before merging, and (b) opt into `git commit -S` with GPG or SSH signing and verify against a known keyring at review time. The plugin does not enforce these; it records the signature and leaves verification to the team's git workflow.
+This RFC preserves the accepted multi-team-approval RFC's threat model intact (§3.9): sign-offs are attested artifacts, not cryptographic attestations; `signer:` is self-asserted; transport inherits the write-access control of whatever moves files. No PR in this RFC introduces a new identity claim or trust assumption.
+
+**PR 3 partial personalization specifically.** The historical-email heuristic reads sign-off files the user already had access to (they're in `.claude/sdlc/sign-offs/`, tracked in the repo). It surfaces no new information — a user who can read their own git history can already infer the same mapping. The hint is advisory, explicitly labeled "based on past sign-offs," and opt-out via config.
+
+Role assignments do not exist in this RFC (accepted RFC keeps identity in the sign-off file, not in config). Teams concerned about role information in repo history should follow the accepted RFC's guidance rather than any new mechanism introduced here.
 
 ## Backward compatibility
 
 Every change is default-off or graceful-degrading.
 
 - Existing plan files without `Version`/`Status` front-matter behave as `Version: 1, Status: active`
-- Existing `config/tools.json` without an `approvals` block behaves as today's single sign-off
+- Existing `config/tools.json` without an `approvals` block behaves as today's single sign-off; accepted multi-team-approval RFC mechanisms activate only when the corresponding keys (`approvals.roles`, `approvals.share_path`, etc.) are present
 - The new SessionStart hook is additive; removing it returns behavior to current
 - `/status` and `/start` are new commands; existing `/plan`, `/analyze`, etc. are untouched
 - The approval packet is a derived artifact; source files remain authoritative and unchanged in shape
-- PR 7 is additive to PR 5: in the same session, multi-role still works exactly as PR 5 describes. Distributed sign-off is opt-in by convention — each approver runs `gate-signoff` on their own machine rather than all in one session
 - PR 8 is additive. Hand-edited `config/tools.json` continues to work untouched; `/configure` only modifies fields the user is actively configuring and always shows a diff first. Users who prefer manual editing never have to invoke it (beyond the first-install prompt, which they can skip)
 - PR 9 is purely additive — existing users see no change until they run `/help` or read the glossary
 - PR 10 modifies output of every skill to append a "Next:" line, but adds no new behavior. Skills with no matching `when` condition print nothing extra, identical to today's behavior
@@ -485,15 +450,13 @@ No migration required for existing users.
 
 ## Implementation checklist
 
-- [ ] PR 1: `/status` command + skill
+- [ ] PR 1: `/status` command + skill (includes sign-off progress render)
 - [ ] PR 2: `/start` command + skill
-- [ ] PR 3: SessionStart plan check hook
+- [ ] PR 3: SessionStart plan check hook (includes opt-out partial personalization)
 - [ ] PR 4: Plan versioning and supersede
-- [ ] PR 8: `/configure` command + env-detect config validation
-- [ ] PR 5: Multi-role approval chain (+ optional tracker notification, + shared chain-visibility render)
-- [ ] PR 9: Glossary + `/help` (with bridge behavior) + shared message library
-- [ ] PR 7: Distributed sign-off via git
-- [ ] PR 6: Approval packet
+- [ ] PR 8: `/configure` command + env-detect config validation (reshaped question bank)
+- [ ] PR 9: Glossary + `/help` (with unordered-parallel callout) + shared message library
+- [ ] PR 6: Approval packet (as `evidence:` field target)
 - [ ] PR 10: Automatic next-step hints (output convention adopted by every skill)
 - [ ] Dogfood on 2–3 real projects
 - [ ] Collect observed blockers; generate next backlog from real usage

--- a/docs/rfcs/notes/README.md
+++ b/docs/rfcs/notes/README.md
@@ -1,0 +1,64 @@
+# `docs/rfcs/notes/`
+
+Working notes that sit alongside RFCs but aren't RFCs themselves. This directory is for in-flight thinking, companion implementation notes, conflict analyses, and shared context that the main repo docs shouldn't carry.
+
+**Start here:** [`_repo-context.md`](./_repo-context.md) — the canonical grounding for any new conversation about the repo. Paste it first.
+
+---
+
+## What belongs here vs. in `docs/rfcs/`
+
+| Lives in `docs/rfcs/` | Lives in `docs/rfcs/notes/` |
+| --- | --- |
+| Accepted RFC | Discussion note leading up to an RFC |
+| Proposed RFC under formal review | Companion implementation note for a specific RFC |
+| Decision the repo now enforces | Conflict analysis between competing proposals |
+| Long-lived reference | Working context, repo state snapshots |
+
+If a note hardens into a decision, promote it to an RFC in the parent directory. If an RFC gets superseded, its companion notes stay here as history.
+
+## Naming conventions
+
+- **Underscore prefix** (`_repo-context.md`) — meta-files for the directory itself. Kept short to sort to the top.
+- **RFC companions** — match the RFC's slug, with a qualifier. Example: `guided-entry-pr7-degradation.md` is the degradation matrix for PR 7 of the guided-entry RFC.
+- **Standalone discussions** — descriptive slug with the phase or area first. Example: `plan-phase-scope-ingest-discussion.md`.
+- **Conflict checks** — slug + `-conflict-check.md`. Use when a proposal needs to be reconciled with an accepted RFC before it can move forward.
+
+## Status vocabulary
+
+Every note should declare its status in the first line after the title. Use one of:
+
+- **discussion** — active thinking; not yet a proposal
+- **draft** — structured enough to review, not ready to accept
+- **companion** — implementation detail for an existing RFC (accepted or draft)
+- **superseded** — kept for history, no longer current; point at what replaced it
+- **archived** — historical record of a path not taken
+
+A note with no status field should be treated as `discussion`.
+
+## Current contents
+
+| File | Status | What it covers |
+| --- | --- | --- |
+| [`_repo-context.md`](./_repo-context.md) | reference | Canonical repo grounding — principles, capability counts, accepted RFCs, open PRs, anti-patterns. Paste first in any new conversation. |
+| [`plan-phase-scope-ingest-discussion.md`](./plan-phase-scope-ingest-discussion.md) | discussion | Proposal for reshaping Phase 1: `scope-ingest` agent + `domain-expert` skill. Includes conflict analysis against accepted multi-team-approval RFC and PR #1. |
+| [`guided-entry-pr7-degradation.md`](./guided-entry-pr7-degradation.md) | companion | Refuse/degrade/hand-off taxonomy for PR 7 of the guided-entry UX RFC (PR #1). |
+
+## Adding a new note
+
+1. Pick a name per the conventions above.
+2. First line after the title: a `> **Status:**` blockquote with one of the vocabulary terms.
+3. Top of the body: a `**Date:**` line, a `**Scope:**` line (what this note is and isn't about), and a `**Related:**` list pointing at any RFCs, PRs, or other notes it depends on.
+4. Add a one-line entry to the "Current contents" table in this README.
+5. If the note meaningfully changes repo state, update `_repo-context.md` too.
+
+## Conventions for the writing itself
+
+These inherit from the repo's documentation discipline and are reiterated here so they apply to notes even when they're informal:
+
+- Ground every claim in observable repo behavior — a hook, a skill, a template, an artifact path. If it can't be grounded, flag it as aspirational or leave it out.
+- No inflated metaphors, manufactured personas, formulaic triplets, false severity, or unsupported compliance assertions.
+- Name what the note *can't* see — missing context, unresolved questions, things deferred — rather than papering over them.
+- Honest tradeoff analysis over persuasive framing.
+
+The anti-pattern list in `_repo-context.md` applies in full.

--- a/docs/rfcs/notes/README.md
+++ b/docs/rfcs/notes/README.md
@@ -42,7 +42,7 @@ A note with no status field should be treated as `discussion`.
 | --- | --- | --- |
 | [`_repo-context.md`](./_repo-context.md) | reference | Canonical repo grounding — principles, capability counts, accepted RFCs, open PRs, anti-patterns. Paste first in any new conversation. |
 | [`_session-handoff.md`](./_session-handoff.md) | reference (overwritten each session) | Short-lived "what just happened" continuity. Key decisions and open items from the most recent session. Paste second after `_repo-context.md` when resuming. |
-| [`plan-phase-scope-ingest-discussion.md`](./plan-phase-scope-ingest-discussion.md) | discussion | Proposal for reshaping Phase 1: `scope-ingest` agent + `domain-expert` skill. Includes conflict analysis against accepted multi-team-approval RFC and PR #1. |
+| [`plan-phase-scope-ingest-discussion.md`](./plan-phase-scope-ingest-discussion.md) | superseded (promoted) | Promoted to `docs/rfcs/scope-ingest.md` (2026-04-25). All conflicts resolved. Kept as historical record of the analysis path. |
 | [`guided-entry-pr7-degradation.md`](./guided-entry-pr7-degradation.md) | superseded | Historical reference for dropped PR 7. Superseded by accepted `multi-team-approval.md` §3.4–§3.6 (file-transport distributed sign-off). Some failure-mode analysis may still inform Tier 2 git transport implementation. |
 
 ## Adding a new note

--- a/docs/rfcs/notes/README.md
+++ b/docs/rfcs/notes/README.md
@@ -41,6 +41,7 @@ A note with no status field should be treated as `discussion`.
 | File | Status | What it covers |
 | --- | --- | --- |
 | [`_repo-context.md`](./_repo-context.md) | reference | Canonical repo grounding — principles, capability counts, accepted RFCs, open PRs, anti-patterns. Paste first in any new conversation. |
+| [`_session-handoff.md`](./_session-handoff.md) | reference (overwritten each session) | Short-lived "what just happened" continuity. Key decisions and open items from the most recent session. Paste second after `_repo-context.md` when resuming. |
 | [`plan-phase-scope-ingest-discussion.md`](./plan-phase-scope-ingest-discussion.md) | discussion | Proposal for reshaping Phase 1: `scope-ingest` agent + `domain-expert` skill. Includes conflict analysis against accepted multi-team-approval RFC and PR #1. |
 | [`guided-entry-pr7-degradation.md`](./guided-entry-pr7-degradation.md) | superseded | Historical reference for dropped PR 7. Superseded by accepted `multi-team-approval.md` §3.4–§3.6 (file-transport distributed sign-off). Some failure-mode analysis may still inform Tier 2 git transport implementation. |
 

--- a/docs/rfcs/notes/README.md
+++ b/docs/rfcs/notes/README.md
@@ -42,7 +42,7 @@ A note with no status field should be treated as `discussion`.
 | --- | --- | --- |
 | [`_repo-context.md`](./_repo-context.md) | reference | Canonical repo grounding — principles, capability counts, accepted RFCs, open PRs, anti-patterns. Paste first in any new conversation. |
 | [`plan-phase-scope-ingest-discussion.md`](./plan-phase-scope-ingest-discussion.md) | discussion | Proposal for reshaping Phase 1: `scope-ingest` agent + `domain-expert` skill. Includes conflict analysis against accepted multi-team-approval RFC and PR #1. |
-| [`guided-entry-pr7-degradation.md`](./guided-entry-pr7-degradation.md) | companion | Refuse/degrade/hand-off taxonomy for PR 7 of the guided-entry UX RFC (PR #1). |
+| [`guided-entry-pr7-degradation.md`](./guided-entry-pr7-degradation.md) | superseded | Historical reference for dropped PR 7. Superseded by accepted `multi-team-approval.md` §3.4–§3.6 (file-transport distributed sign-off). Some failure-mode analysis may still inform Tier 2 git transport implementation. |
 
 ## Adding a new note
 

--- a/docs/rfcs/notes/_repo-context.md
+++ b/docs/rfcs/notes/_repo-context.md
@@ -1,0 +1,151 @@
+# Repo context — claude-sdlc
+
+> **Purpose.** Paste or reference this file at the start of any new conversation about the repo so the assistant has accurate grounding without re-fetching everything. Keep it short and current. If a fact drifts, fix it here first.
+
+**Repo:** https://github.com/lantisprime/claude-sdlc
+**Last updated:** 2026-04-24
+
+---
+
+## What the repo is
+
+An 8-phase SDLC plugin for Claude Code that gates every coding task behind planning, surgical-edit enforcement, and human sign-off artifacts. Trades velocity for discipline, on purpose.
+
+## Core principles (load-bearing — do not erode)
+
+1. **Human in the lead, always.** Subagents and hooks never advance a phase on their own.
+2. **Plan before code.** `plan-gate.sh` blocks `Edit`/`Write` when no plan exists for the task.
+3. **Surgical edits.** Only plan-listed files and functions. No adjacent-function edits. No "while I'm here" cleanups.
+4. **Work-item traceability.** Every build references a REQ ID, ticket, or signed CR.
+5. **Graceful degradation.** Missing integrations fall back to local markdown/JSON artifacts. Never silently skip a check.
+6. **Stack-agnostic.** Formatter, linter, runners, scanners all configured via `config/tools.json`. Nothing hardcoded.
+
+## 8 phases and the commands that run them
+
+1. Plan — `/plan`
+2. Analyze — `/analyze`
+3. Design — `/design`
+4. Build — `/build`
+5. Test — `/test`
+6. Deploy — `/deploy`
+7. Support — `/support`
+8. Docs — `/docs` (cross-cutting)
+
+Plus: `/review` (cross-cutting diff review), `/fix-fast` (bug-only shortcut, ≤2 files, ≤50 LOC), `/token-review` (phase token usage).
+
+Each phase writes a gate file at `.claude/sdlc/gates/<phase>-<slug>.md`. The next phase refuses to start until the prior gate is signed.
+
+## Current capability counts
+
+- **Commands:** 11 (8 phase + `/review` + `/fix-fast` + `/token-review`)
+- **Skills:** 14 (8 phase + 6 cross-cutting: `scoping`, `surgical-edit`, `minimal-code`, `security-review`, `api-integration`, `gate-signoff`)
+- **Agents:** 4 (`architect`, `test-designer`, `security-reviewer`, `observability`) — bounded write scope, propose-only
+- **Hooks:** 10 registered in `hooks/hooks.json` (+ optional `token-tracker.sh`)
+- **Templates:** 10
+
+## Hook severity model
+
+- **Block (exit 2)** — refuses the tool call. Reserved for severe consequences: no plan, unsigned CR, confirmed secret.
+- **Warn (stderr, exit 0)** — surfaces signal, human decides. Scope drift, adjacent-function edits, test-scope mismatches.
+
+Warnings are not auto-blockers-in-waiting. The adjacent-function detector uses git hunk headers (imperfect) — aggressive blocking there would halt legitimate work.
+
+## Artifact tree in the consuming repo
+
+```
+.claude/sdlc/
+├── env.json                # detected integrations
+├── scope.md                # project scope statement
+├── plans/
+├── requirements/
+├── architecture/
+├── tech-specs/
+├── test-cases/
+├── test-scripts/
+├── tickets/
+├── change-requests/
+├── sign-offs/              # per accepted RFC, one file per signer
+├── gates/                  # phase gate files
+├── defects/
+├── deployments/
+├── monitoring/
+└── docs/
+```
+
+## External connectivity
+
+Four channels, auto-detected by `env-detect.sh` on SessionStart:
+
+- **VCS:** Git + host CLI (gh for GitHub, etc.)
+- **Issue tracker:** host-native for GitHub/GitLab/Bitbucket; MCP for Jira/Linear
+- **CI:** filesystem sniffing only (never triggers pipelines)
+- **Observability:** MCP for Grafana/Datadog; IaC proposals for CloudWatch
+- **UX tooling:** MCP for Figma; local markdown fallback
+- **Dev-time APIs:** direct HTTP probes via `api-integration`
+
+All MCP-mediated changes are propose-only.
+
+## Sharp edge — frontend UX track
+
+Frontend tasks halt in Phase 2 until some UX artifact exists at `.claude/sdlc/architecture/ux/<task-slug>.md`. Any form counts: Figma link, PDF mockups, screenshots, hand-drawn wireframes, or a written description. Backend-only tasks skip the UX track entirely.
+
+## Accepted RFCs
+
+- **`docs/rfcs/multi-team-approval.md`** (accepted 2026-04-19) — defines:
+  - Sign-off files at `.claude/sdlc/sign-offs/<REQ-ID>-<role>.md` (one file per signer)
+  - `APPROVALS.md` reconciler artifact
+  - Transport ladder Tier 0–3 (how approvals arrive)
+  - 9-role set (suggested vocabulary)
+  - *(Full text not inlined here — read the RFC directly when details are needed.)*
+
+## Open PRs
+
+- **PR #1** — *Draft: Guided-entry UX RFC (reshape pending vs. accepted multi-team-approval)*
+  - Branch: `rfc/guided-entry-ux-draft`
+  - Status: draft, do not merge. Path A reshape pending.
+  - Proposes 10 PRs focused on reducing user cognitive load and enabling multi-computer approvals.
+  - **Known conflict:** PRs 5 and 7 disagree with the accepted multi-team-approval model and will be dropped.
+  - **Complementary (will survive reshape):** PRs 1, 2, 3, 4, 6, 8, 9, 10.
+  - **Pending discussions (deferred):** A. Workflow templates, B. Back/cancel navigation, C. Error-message audit, D. TodoWrite integration for long-running phases, E. Per-phase `/status` detail.
+
+## Active discussions (not yet PR'd)
+
+- **Plan phase — scope ingest + domain expert.** See `docs/rfcs/notes/plan-phase-scope-ingest-discussion.md` in this same notes directory.
+
+## Anti-patterns the repo explicitly guards against
+
+Documented design intent lives in `CLAUDE.md`. Short list of things that *look* like improvements but aren't:
+
+- Auto-advancing phases (breaks "human in the lead")
+- Widening `/fix-fast` eligibility beyond bug-only / ≤2 files / ≤50 LOC
+- Promoting warn-level hooks to block without evidence
+- Silently skipping a check when an integration is missing
+- Hardcoding tool choices instead of routing through `config/tools.json`
+- Adding commands the human has to memorize when a skill would do
+
+## Writing / framing anti-patterns (for documentation)
+
+Flagged explicitly by the project owner as things to avoid in any documentation, wiki, or RFC prose for this repo:
+
+- Inflated metaphors ("Trojan Horse for autonomy", "velocity unlock", etc.)
+- Manufactured personas or job titles used as rhetorical devices
+- Formulaic triplet structures when a single clear sentence does the job
+- False severity escalation (calling warnings "blockers", advisory findings "critical")
+- Unsupported compliance assertions (implying the plugin delivers SOC2 / PCI-DSS / HIPAA guarantees it does not)
+- Aspirational framing that outruns what the repo actually does
+
+When in doubt, ground every claim in observable repo behavior (a hook, a skill, a template, an artifact path). If it can't be grounded, either leave it out or flag it as aspirational.
+
+## Validation metrics (targets when tuning)
+
+- Plan-first compliance: 100%
+- Work-item validation: 100%
+- Scope discipline (files touched ÷ files in scope): 1.0
+- Adjacent-function modifications per task: 0
+- Test scope ratio (tests modified ÷ code modified): ≈ 1.0
+
+## How to use this file
+
+- **Starting a new conversation about the repo:** paste this file first, then ask your question.
+- **Something here is wrong or stale:** fix it here before making the decision that depends on it. This file is the index; drift here is worse than drift anywhere else.
+- **Adding a new active discussion:** add a one-line entry under "Active discussions" pointing to the note file in this directory.

--- a/docs/rfcs/notes/_repo-context.md
+++ b/docs/rfcs/notes/_repo-context.md
@@ -3,7 +3,7 @@
 > **Purpose.** Paste or reference this file at the start of any new conversation about the repo so the assistant has accurate grounding without re-fetching everything. Keep it short and current. If a fact drifts, fix it here first.
 
 **Repo:** https://github.com/lantisprime/claude-sdlc
-**Last updated:** 2026-04-24 (post-reshape)
+**Last updated:** 2026-04-25 (Pending A resolved)
 
 ---
 
@@ -106,7 +106,7 @@ Frontend tasks halt in Phase 2 until some UX artifact exists at `.claude/sdlc/ar
   - Proposes 8 PRs layering UX surfaces over the accepted sign-off mechanism: 1 (`/status` with sign-off render), 2 (`/start`), 3 (SessionStart plan-check with opt-out personalization), 4 (plan versioning), 6 (approval packet as `evidence:` target), 8 (`/configure` with reshaped question bank), 9 (glossary + `/help` + unordered-parallel callout + message library), 10 (auto next-step hints).
   - **Dropped during reshape:** former PRs 5 (in-session chain) and 7 (commits-as-signatures) — both duplicated or conflicted with the accepted RFC's model. Companion note `guided-entry-pr7-degradation.md` marked `superseded`.
   - **Compensating additions (option-b):** PR 1 unordered sign-off state render, PR 3 opt-out historical-email personalization, PR 9 unordered-parallel callout — together recover most of the multi-role UX affordance without reopening the conflict.
-  - **Pending discussions (deferred):** A. Workflow templates (coordinate with scope-ingest discussion), B. Back/cancel navigation, C. Error-message audit, D. TodoWrite integration for long-running phases, E. Per-phase `/status` detail.
+  - **Pending discussions:** A. Workflow templates — **resolved 2026-04-25 (keep orthogonal; advisory `suggested_roles:` bridge in domain file schema)**. B–E deferred: B. Back/cancel navigation, C. Error-message audit, D. TodoWrite integration, E. Per-phase `/status` detail.
 
 ## Active discussions (not yet PR'd)
 

--- a/docs/rfcs/notes/_repo-context.md
+++ b/docs/rfcs/notes/_repo-context.md
@@ -3,7 +3,7 @@
 > **Purpose.** Paste or reference this file at the start of any new conversation about the repo so the assistant has accurate grounding without re-fetching everything. Keep it short and current. If a fact drifts, fix it here first.
 
 **Repo:** https://github.com/lantisprime/claude-sdlc
-**Last updated:** 2026-04-25 (Pending A resolved)
+**Last updated:** 2026-04-25 (scope-ingest RFC promoted)
 
 ---
 
@@ -108,9 +108,9 @@ Frontend tasks halt in Phase 2 until some UX artifact exists at `.claude/sdlc/ar
   - **Compensating additions (option-b):** PR 1 unordered sign-off state render, PR 3 opt-out historical-email personalization, PR 9 unordered-parallel callout — together recover most of the multi-role UX affordance without reopening the conflict.
   - **Pending discussions:** A. Workflow templates — **resolved 2026-04-25 (keep orthogonal; advisory `suggested_roles:` bridge in domain file schema)**. B–E deferred: B. Back/cancel navigation, C. Error-message audit, D. TodoWrite integration, E. Per-phase `/status` detail.
 
-## Active discussions (not yet PR'd)
+## Draft RFCs (not yet PR'd)
 
-- **Plan phase — scope ingest + domain expert.** See `docs/rfcs/notes/plan-phase-scope-ingest-discussion.md` in this same notes directory.
+- **Scope ingest + domain expert** — `docs/rfcs/scope-ingest.md` (promoted from discussion note 2026-04-25). Proposes `scope-ingest` agent + `domain-expert` skill hanging off `/plan`. All accepted-RFC conflicts resolved. One open question before implementation: OQ-SCOPE-1 (pseudo-phase gate vs. new artifact class for scope gate file).
 
 ## Anti-patterns the repo explicitly guards against
 

--- a/docs/rfcs/notes/_repo-context.md
+++ b/docs/rfcs/notes/_repo-context.md
@@ -3,7 +3,7 @@
 > **Purpose.** Paste or reference this file at the start of any new conversation about the repo so the assistant has accurate grounding without re-fetching everything. Keep it short and current. If a fact drifts, fix it here first.
 
 **Repo:** https://github.com/lantisprime/claude-sdlc
-**Last updated:** 2026-04-25 (scope-ingest RFC promoted)
+**Last updated:** 2026-04-25 (scope-ingest RFC reviewed + OQ-SCOPE-1 resolved)
 
 ---
 
@@ -110,7 +110,7 @@ Frontend tasks halt in Phase 2 until some UX artifact exists at `.claude/sdlc/ar
 
 ## Draft RFCs (not yet PR'd)
 
-- **Scope ingest + domain expert** — `docs/rfcs/scope-ingest.md` (promoted from discussion note 2026-04-25). Proposes `scope-ingest` agent + `domain-expert` skill hanging off `/plan`. All accepted-RFC conflicts resolved. One open question before implementation: OQ-SCOPE-1 (pseudo-phase gate vs. new artifact class for scope gate file).
+- **Scope ingest + domain expert** — `docs/rfcs/scope-ingest.md` (promoted 2026-04-25, second-opinion review applied). Proposes `scope-ingest` agent + `domain-expert` skill hanging off `/plan`. All conflicts and open questions resolved. OQ-SCOPE-1 resolved: pseudo-phase gate for v1; new artifact class deferred to v2 (trigger: post-ship operator confusion or reconciler divergence). Implementation checklist unblocked — start with `domains/_schema.md` + seed files.
 
 ## Anti-patterns the repo explicitly guards against
 

--- a/docs/rfcs/notes/_repo-context.md
+++ b/docs/rfcs/notes/_repo-context.md
@@ -3,7 +3,7 @@
 > **Purpose.** Paste or reference this file at the start of any new conversation about the repo so the assistant has accurate grounding without re-fetching everything. Keep it short and current. If a fact drifts, fix it here first.
 
 **Repo:** https://github.com/lantisprime/claude-sdlc
-**Last updated:** 2026-04-24
+**Last updated:** 2026-04-24 (post-reshape)
 
 ---
 
@@ -100,13 +100,13 @@ Frontend tasks halt in Phase 2 until some UX artifact exists at `.claude/sdlc/ar
 
 ## Open PRs
 
-- **PR #1** — *Draft: Guided-entry UX RFC (reshape pending vs. accepted multi-team-approval)*
+- **PR #1** — *Draft: Guided-entry, session resume, and approval UX (reshaped)*
   - Branch: `rfc/guided-entry-ux-draft`
-  - Status: draft, do not merge. Path A reshape pending.
-  - Proposes 10 PRs focused on reducing user cognitive load and enabling multi-computer approvals.
-  - **Known conflict:** PRs 5 and 7 disagree with the accepted multi-team-approval model and will be dropped.
-  - **Complementary (will survive reshape):** PRs 1, 2, 3, 4, 6, 8, 9, 10.
-  - **Pending discussions (deferred):** A. Workflow templates, B. Back/cancel navigation, C. Error-message audit, D. TodoWrite integration for long-running phases, E. Per-phase `/status` detail.
+  - Status: draft, reshaped 2026-04-24 against accepted `multi-team-approval.md`; ready for review.
+  - Proposes 8 PRs layering UX surfaces over the accepted sign-off mechanism: 1 (`/status` with sign-off render), 2 (`/start`), 3 (SessionStart plan-check with opt-out personalization), 4 (plan versioning), 6 (approval packet as `evidence:` target), 8 (`/configure` with reshaped question bank), 9 (glossary + `/help` + unordered-parallel callout + message library), 10 (auto next-step hints).
+  - **Dropped during reshape:** former PRs 5 (in-session chain) and 7 (commits-as-signatures) — both duplicated or conflicted with the accepted RFC's model. Companion note `guided-entry-pr7-degradation.md` marked `superseded`.
+  - **Compensating additions (option-b):** PR 1 unordered sign-off state render, PR 3 opt-out historical-email personalization, PR 9 unordered-parallel callout — together recover most of the multi-role UX affordance without reopening the conflict.
+  - **Pending discussions (deferred):** A. Workflow templates (coordinate with scope-ingest discussion), B. Back/cancel navigation, C. Error-message audit, D. TodoWrite integration for long-running phases, E. Per-phase `/status` detail.
 
 ## Active discussions (not yet PR'd)
 

--- a/docs/rfcs/notes/_session-handoff.md
+++ b/docs/rfcs/notes/_session-handoff.md
@@ -3,10 +3,10 @@
 > **Status:** current working state (overwritten each session)
 
 **Date:** 2026-04-25
-**Scope:** Key decisions and open items from three sessions: guided-entry reshape, Pending A resolution, scope-ingest RFC promotion. Complements `_repo-context.md` with short-lived "what just happened" continuity.
+**Scope:** Key decisions and open items from three sessions: guided-entry reshape, Pending A + scope-ingest conflicts, scope-ingest RFC promotion + review + OQ-SCOPE-1 resolution.
 **Related:**
-- [`guided-entry-session-resume-multi-role.md`](../guided-entry-session-resume-multi-role.md) — main RFC, all pending discussions resolved or deferred; PR #1 marked ready for review
-- [`scope-ingest.md`](../scope-ingest.md) — formal RFC draft as of 2026-04-25
+- [`guided-entry-session-resume-multi-role.md`](../guided-entry-session-resume-multi-role.md) — PR #1, ready for review
+- [`scope-ingest.md`](../scope-ingest.md) — formal RFC draft, all open questions resolved, implementation checklist unblocked
 - [`multi-team-approval.md`](../multi-team-approval.md) — accepted RFC; all constraints honored
 - PR #1: https://github.com/lantisprime/claude-sdlc/pull/1
 
@@ -14,47 +14,42 @@
 
 ## Binding decisions (cumulative)
 
-### Reshape of guided-entry RFC (2026-04-24)
+### Guided-entry RFC reshape (2026-04-24)
 
-- **Dropped** PR 5 and PR 7 — accepted RFC's model can't host them.
-- **Kept + reworked** PRs 1, 2, 3, 4, 6, 8, 9, 10.
-- **Ship order:** 1 → 2 → 3 → 4 → 8 → 9 → 6 → 10. Hard deps: PR 10 last, PR 4 before PR 6.
-- **Compensating additions (option-b):** PR 1 unordered pipe render, PR 3 historical-email heuristic, PR 9 unordered-parallel callout.
+- Dropped PRs 5 + 7; kept + reworked PRs 1, 2, 3, 4, 6, 8, 9, 10.
+- Ship order: 1 → 2 → 3 → 4 → 8 → 9 → 6 → 10. Hard deps: PR 10 last, PR 4 before PR 6.
+- Compensating additions (option-b): PR 1 unordered pipe render, PR 3 historical-email heuristic, PR 9 unordered-parallel callout.
+- PR #1 marked ready-for-review 2026-04-25.
 
-### Pending A: workflow templates vs. domain files — keep orthogonal (2026-04-25)
+### Pending A: keep orthogonal (2026-04-25)
 
-Workflow presets (PR #1 §A, `/configure` Q5) = pure config. Domain files (`domains/payments.md`) = pure knowledge. Advisory bridge: optional `suggested_roles: []` in domain file frontmatter; plan skill surfaces it but does not enforce. Written back to scope-ingest note, guided-entry RFC, and `_repo-context.md`.
+Workflow presets = pure config. Domain files = pure knowledge. Advisory bridge: optional `suggested_roles: []`; plan skill surfaces it into `## Domain context` advisory only — never into gate file's `## Required sign-offs` block.
 
-### Scope-ingest conflict resolutions — written back (2026-04-25)
+### Scope-ingest RFC (2026-04-25)
 
-All four conflicts with `multi-team-approval.md` resolved in scope-ingest note and carried into the formal RFC:
-1. Sign-off filename → `REQ-SCOPE-<project-slug>`, file `sign-offs/REQ-SCOPE-<slug>-product.md`
-2. Default signer → `product`; drop `scope-owner`; `suggested_roles` advisory only
+Promoted from discussion note. Second-opinion review applied (8 findings). Key constraints locked in:
+- `scope-ingest` write restriction is a convention (agent instructions), not a capability boundary
+- `required:` question tag is warn-level, not a hard block (per CLAUDE.md hook philosophy)
+- `suggested_roles` → `## Domain context` advisory only; gate file block comes from `approvals.roles` or explicit human input
+- `gate_hash` required in scope gate template (per accepted RFC §6.5)
+- Cross-phase `domain-expert` reuse (`/analyze`, `/design`) deferred to v1 non-goals
+
+### OQ-SCOPE-1 resolved: pseudo-phase gate for v1 (2026-04-25)
+
+Scope gate file at `.claude/sdlc/gates/scope-<project>.md` — same shape as phase gate files, reconciler handles it with no code changes. Label imprecision ("scope isn't a phase") addressed via glossary.
+
+**New artifact class deferred to v2.** Trigger: if post-ship usage shows the "pre-Plan gate" label causes operator confusion, or if reconciler behavior for scope needs to diverge. V2 checklist: (a) `scope_gate` entry in `env.json` artifact registry, (b) rename convention if needed, (c) reconciler branch. No data migration — file content is identical either way.
+
+### Scope-ingest conflict resolutions (written back 2026-04-25)
+
+1. Sign-off filename → `REQ-SCOPE-<project-slug>`; file `sign-offs/REQ-SCOPE-<slug>-product.md`
+2. Default signer → `product`; `suggested_roles` advisory only
 3. Transport → Tier 0 for v1; same config keys as phase sign-offs
-4. Reconciler → scope gate at `.claude/sdlc/gates/scope-<project>.md` with `## Required sign-offs` block
+4. Reconciler → pseudo-phase gate at `.claude/sdlc/gates/scope-<project>.md`
 
-### Scope-ingest RFC promoted (2026-04-25)
+### Accepted-RFC constraints honored throughout
 
-`docs/rfcs/notes/plan-phase-scope-ingest-discussion.md` → `docs/rfcs/scope-ingest.md`.
-
-RFC contents:
-- `scope-ingest` agent (narrow write scope: `scope-drafts/` only; provenance-traced)
-- `domain-expert` skill (read-and-inject; `domains/` directory; `suggested_roles` advisory bridge)
-- Modified `/plan` flow (6 steps; user surface unchanged)
-- All sign-off alignment resolved
-- `domains/_schema.md` + seed files (`payments.md`, `auth.md`) specified
-- OQ-SCOPE-1 open: pseudo-phase gate vs. new artifact class (see §6)
-- 14-item implementation checklist
-
-Discussion note status: `superseded (promoted)`.
-
-### PR #1 ready-for-review (2026-04-25)
-
-Marked ready via `gh pr ready 1`. No longer draft.
-
-### Constraints honored from accepted `multi-team-approval.md`
-
-- Signer identity in sign-off file (`signer:`), never in config
+- Signer identity in `signer:` field, never in config
 - No role-to-email map in config
 - No signed-commit enforcement
 - No tracker-notification-on-signature
@@ -64,10 +59,6 @@ Marked ready via `gh pr ready 1`. No longer draft.
 
 ## Open items carried forward
 
-### OQ-SCOPE-1 (resolve before scope-ingest implementation begins)
-
-Pseudo-phase gate vs. new artifact class for `.claude/sdlc/gates/scope-<project>.md`. Proposal: ship v1 as pseudo-phase gate (low cost; upgrade path is a rename + registry entry if confusion causes operator errors). Answer pending.
-
 ### OQ-1 in guided-entry RFC (resolve before PR 4 implementation)
 
 PR 4 material-edit detection for `In-scope files`. Proposal: set-change semantics (additions/removals trigger version bump; reordering doesn't).
@@ -76,23 +67,32 @@ PR 4 material-edit detection for `In-scope files`. Proposal: set-change semantic
 
 B. Back/cancel navigation, C. Error-message audit, D. TodoWrite integration, E. Per-phase `/status` detail.
 
+### Scope-ingest implementation checklist (unblocked)
+
+All open questions resolved. 13 remaining checklist items in RFC §14 — ready to begin. Natural first step: `domains/_schema.md` + seed files (cheapest; validates shape before building consumers).
+
 ---
 
 ## Recommended next-session start
 
-**Primary: resolve OQ-SCOPE-1** (pseudo-phase gate vs. artifact class) before the scope-ingest implementation checklist can begin.
+**Primary: begin scope-ingest implementation — `domains/_schema.md` + seed files.**
 
-Why first: it's a contained yes/no with a clear proposal already in RFC §6. Resolving it unblocks the entire 14-item implementation checklist.
+Why now: OQ-SCOPE-1 resolved; all RFC constraints locked in; implementation checklist is fully unblocked. The schema + seed files are the cheapest first step and validate the domain file shape before anything consumes it.
 
-After OQ-SCOPE-1:
-1. Begin scope-ingest implementation — `domains/_schema.md` and seed files are the cheapest first step per §14 checklist
-2. Resolve OQ-1 (guided-entry PR 4) before its implementation begins
+After seed files:
+1. Build `domain-expert` skill (reads `_index.json`, injects `## Domain context`)
+2. Dry-run against 3–5 past plan artifacts before building the agent
+3. Then `scope-ingest` agent (markdown + plain text first)
+
+Also outstanding (lower priority): OQ-1 in guided-entry RFC, resolve before PR 4 implementation begins.
 
 ---
 
 ## Commits this session
 
-- `ba39520` — docs(rfc): resolve Pending A, write back scope-ingest conflicts
+- `ba39520` — resolve Pending A, write back scope-ingest conflicts
+- `725bda4` — promote scope-ingest discussion note to formal RFC
+- `a9a0528` — apply second-opinion review findings (8 findings)
 - *(current session commit pending)*
 
 ## Conventions reinforced
@@ -107,4 +107,4 @@ After OQ-SCOPE-1:
 
 1. Paste `_repo-context.md` first
 2. Paste this file second
-3. Start with OQ-SCOPE-1 — read RFC §6, confirm or replace the proposal
+3. Start with `domains/_schema.md` — write the domain file contract before the first seed file

--- a/docs/rfcs/notes/_session-handoff.md
+++ b/docs/rfcs/notes/_session-handoff.md
@@ -2,112 +2,111 @@
 
 > **Status:** current working state (overwritten each session)
 
-**Date:** 2026-04-24
-**Scope:** Key decisions and open items from the most recent session on the guided-entry UX RFC (PR #1). Complements `_repo-context.md` (long-lived grounding) with short-lived "what just happened" continuity. Overwrite — don't append — when a new session closes.
+**Date:** 2026-04-25
+**Scope:** Key decisions and open items from the two most recent sessions on the guided-entry UX RFC (PR #1) and the scope-ingest discussion note. Complements `_repo-context.md` (long-lived grounding) with short-lived "what just happened" continuity. Overwrite — don't append — when a new session closes.
 **Related:**
-- [`guided-entry-session-resume-multi-role.md`](../guided-entry-session-resume-multi-role.md) — main RFC, reshaped this session
-- [`multi-team-approval.md`](../multi-team-approval.md) — accepted RFC read in full this session
-- [`plan-phase-scope-ingest-discussion.md`](./plan-phase-scope-ingest-discussion.md) — overlaps with Pending A
+- [`guided-entry-session-resume-multi-role.md`](../guided-entry-session-resume-multi-role.md) — main RFC, all pending discussions now resolved or deferred
+- [`multi-team-approval.md`](../multi-team-approval.md) — accepted RFC; constraints honored throughout
+- [`plan-phase-scope-ingest-discussion.md`](./plan-phase-scope-ingest-discussion.md) — all conflicts resolved; ready for RFC promotion
 - PR #1: https://github.com/lantisprime/claude-sdlc/pull/1
 
 ---
 
-## Binding decisions this session
+## Binding decisions (cumulative)
 
-### Reshape of guided-entry RFC
+### Reshape of guided-entry RFC (2026-04-24)
 
 - **Dropped** PR 5 (`approvals.chain` + assignments map) and PR 7 (commits-as-signatures, env-var identity). Independent reviewer confirmed no reshape path existed — the accepted RFC's parallel one-file-per-signer model can't host a chain render, and its self-asserted `signer:` field can't be replaced by commit authorship.
 - **Kept + reworked** PRs 1, 2, 3, 4, 6, 8, 9, 10 against accepted-RFC vocabulary.
 - **Ship order (final):** 1 → 2 → 3 → 4 → 8 → 9 → 6 → 10.
-- **Hard dependencies (the only true constraints):** PR 10 must ship last (rewrites every skill's output shape); PR 4 must precede PR 6 (delta section consumes version machinery). Everything else is rollout preference, not coupling.
+- **Hard dependencies:** PR 10 must ship last (rewrites every skill's output shape); PR 4 must precede PR 6 (delta section consumes version machinery). Everything else is rollout preference.
 
-### Compensating additions (option-b, chosen over option-a)
+### Compensating additions (option-b, 2026-04-24)
 
-Three additions to recover most of the multi-role UX lost with PR 5, honoring accepted-RFC constraints:
+- **PR 1** — unordered pipe render: `security ✓ | product ✓ | compliance □`. Honest about the parallel-not-sequential mechanism.
+- **PR 3** — opt-out historical-email heuristic. Matches `git config user.email` against `signer:` on past sign-off files. Advisory, labeled "based on past sign-offs," config key `display.session_signoff_hints`. No role-to-email map in config.
+- **PR 9** — explicit unordered-parallel callout in glossary + `/help sign-offs`.
 
-- **PR 1** — unordered pipe render for active gate: `security ✓ | product ✓ | compliance □`. Honest about the parallel-not-sequential mechanism.
-- **PR 3** — opt-out historical-email heuristic. Matches `git config user.email` against `signer:` fields on past sign-off files. Advisory, labeled "based on past sign-offs," config key `display.session_signoff_hints`. **No role-to-email map introduced in config.**
-- **PR 9** — explicit unordered-parallel callout in glossary + `/help sign-offs`. Prevents users from assuming chain-style ordering that doesn't exist.
+### Pending A resolved: workflow templates vs. domain files (2026-04-25)
+
+**Decision: keep orthogonal.**
+
+- **Workflow presets** (PR #1 §A, `/configure` Q5) = pure config: `approvals.roles` + transport defaults. Answer "how does your team manage sign-offs?"
+- **Domain files** (`domains/payments.md` etc.) = pure knowledge: glossary, NFRs, regulatory concerns, gap questions. Answer "what domain-specific constraints apply?"
+- **Advisory bridge:** domain file schema gains optional `suggested_roles: []`. Plan skill surfaces it at plan-time as context; does not enforce or override `approvals.roles`. Absent and empty list are equivalent.
+- Both artifacts have separate owners and evolve independently. No coordination gate going forward.
+
+Written back to: scope-ingest note (open question resolved, schema updated), guided-entry RFC (Pending A section), `_repo-context.md` (PR #1 entry).
+
+### Scope-ingest conflict resolutions (2026-04-24, written back 2026-04-25)
+
+All four conflicts against `multi-team-approval.md` now recorded in `plan-phase-scope-ingest-discussion.md`:
+
+1. Sign-off filename → synthetic REQ-ID `REQ-SCOPE-<project-slug>`; file: `sign-offs/REQ-SCOPE-<slug>-product.md`
+2. Default signer role → `product`; drop tentative `scope-owner`; domain files may declare `suggested_roles` for regulated domains
+3. Transport → same ladder as other sign-offs, Tier 0 only for v1
+4. Reconciler → scope gate file at `.claude/sdlc/gates/scope-<project>.md` with `## Required sign-offs` block; pseudo-phase gate model
 
 ### Constraints honored from accepted `multi-team-approval.md`
 
-Guardrails every future PR must respect:
-
 - Signer identity lives in the sign-off file (`signer:` field), never in config
 - No role-to-email map in config
-- No signed-commit enforcement in the plugin (team workflow, outside scope)
-- No tracker-notification-on-signature (would need its own mini-RFC)
-- Sign-offs are parallel, not sequential — no chain rendering in any UX surface
+- No signed-commit enforcement in the plugin
+- No tracker-notification-on-signature
+- Sign-offs are parallel, not sequential — no chain rendering
 
-### Second-opinion review findings applied
-
-Commit `d647593` addresses five findings:
-
-1. PR 8 scope note ("Deliberately excluded from Q5–Q8") moved above the question list and inlined at Q5/Q6
-2. Pending A "Small team" preset role list changed from `[product, tech_lead]` to `[product, qa]` (inside the 9-role set); added paragraph pointing Custom users at §3.2 for free-form labels
-3. Ship-order prose softened — separated hard deps from rollout preferences
-4. Dropped unverifiable claims ("smaller than pre-reshape draft," "largest single cognitive-load win")
-5. Added new Open questions section with OQ-1 (PR 4 material-edit detection)
-
-Reviewer verdict: structural reshape sound, vocabulary clean, threat model preserved.
+---
 
 ## Open items carried forward
 
-### OQ-1 (now in RFC body, resolve before PR 4 implementation)
+### OQ-1 (in RFC body, resolve before PR 4 implementation)
 
 PR 4 material-edit detection for `In-scope files`. Proposal: set-change semantics (additions/removals trigger version bump; reordering doesn't).
 
-### Pending discussions (A–E, in RFC body)
+### Pending B–E (in RFC body, deferred)
 
-- **A.** Workflow templates in `/configure` — **overlaps with scope-ingest note's workflow-template-vs-domain-file question** → resolve A first
 - **B.** Back/cancel navigation in interactive flows
 - **C.** Error-message audit to three-part template
 - **D.** TodoWrite integration for long-running phases
 - **E.** Per-phase checklist rendering in `/status`
 
-### Scope-ingest note conflicts — now unblocked
+### Scope-ingest RFC promotion
 
-Reading the accepted RFC resolved all four conflicts listed in `plan-phase-scope-ingest-discussion.md`. Resolutions captured here but **not yet written back to that note** — do it next session before or during the scope-ingest RFC promotion:
+`plan-phase-scope-ingest-discussion.md` is now unblocked:
+- All 4 accepted-RFC conflicts resolved and written back
+- Pending A coordination gate lifted
+- One remaining open: pseudo-phase-gate vs. new artifact class for scope (deferred to promotion)
+- Next: draft `docs/rfcs/scope-ingest.md`
 
-1. Sign-off filename → synthetic REQ-ID `REQ-SCOPE-<project-slug>`
-2. Multi-role → default signer is `product`; drop tentative `scope-owner`; domain files declare additional roles for regulated domains
-3. Transport → same ladder as other sign-offs, Tier 0 only for v1
-4. Reconciler → scope gate file at `.claude/sdlc/gates/scope-<project>.md` with `## Required sign-offs` block
-
-Remaining open: treat scope as pseudo-phase gate (cheap) vs. new sign-offable artifact class (cleaner). Defer to scope-ingest RFC promotion.
+---
 
 ## Recommended next-session start
 
-**Primary: Pending A — workflow templates vs. domain files unification.**
+**Primary: mark PR #1 ready-for-review on GitHub** (currently draft).
 
-Why A first:
+Why now: all blocking conflicts resolved (reshape 2026-04-24, Pending A 2026-04-25). OQ-1 and Pending B–E are deferrable post-merge questions.
 
-- Dual-listed in two active threads (PR #1 pending, scope-ingest note)
-- Gates scope-ingest's "decide unification before building seed domain files" next action
-- Contained decision (unify / keep orthogonal / merge indices split content) with three concrete options
-- Shapes downstream vocabulary for two RFCs before any implementation PR opens
+If that's quick, next candidates:
+1. Begin scope-ingest RFC promotion: draft `docs/rfcs/scope-ingest.md` from the discussion note
+2. Resolve OQ-1 (PR 4 material-edit detection) before implementation begins
 
-If A resolves quickly, next candidates:
-
-1. Write A's resolution back to `plan-phase-scope-ingest-discussion.md`
-2. Mark PR #1 ready-for-review on GitHub (currently draft)
-3. Begin scope-ingest RFC promotion (note → formal RFC)
+---
 
 ## Commits this session
 
-- `2e2a085` — reshape guided-entry RFC against accepted multi-team-approval
-- `d647593` — address second-opinion review findings
+- `0ca09ff` — docs(notes): add session handoff for next-session pickup
+- *(current session commit pending)*
 
 ## Conventions reinforced
 
 - Co-Authored-By: Claude Opus 4.7 trailer on every commit
 - Example identity: `juan.delacruz@acme.com` (matches accepted RFC line 81)
-- Propose edits before making them (doc changes — non-trivial)
+- Propose edits before making them (doc changes — non-trivial); skip on explicit "go"
 - Second-opinion review after feature design, before implementation
-- Ground every claim in observable repo behavior; no inflated metaphors or unsupported claims
+- Ground every claim in observable repo behavior
 
 ## To resume in a new session
 
 1. Paste `_repo-context.md` first (long-lived grounding)
 2. Paste this file second ("what just happened")
-3. Start with Pending A
+3. Mark PR #1 ready-for-review, then begin scope-ingest RFC promotion

--- a/docs/rfcs/notes/_session-handoff.md
+++ b/docs/rfcs/notes/_session-handoff.md
@@ -1,0 +1,113 @@
+# Session handoff
+
+> **Status:** current working state (overwritten each session)
+
+**Date:** 2026-04-24
+**Scope:** Key decisions and open items from the most recent session on the guided-entry UX RFC (PR #1). Complements `_repo-context.md` (long-lived grounding) with short-lived "what just happened" continuity. Overwrite — don't append — when a new session closes.
+**Related:**
+- [`guided-entry-session-resume-multi-role.md`](../guided-entry-session-resume-multi-role.md) — main RFC, reshaped this session
+- [`multi-team-approval.md`](../multi-team-approval.md) — accepted RFC read in full this session
+- [`plan-phase-scope-ingest-discussion.md`](./plan-phase-scope-ingest-discussion.md) — overlaps with Pending A
+- PR #1: https://github.com/lantisprime/claude-sdlc/pull/1
+
+---
+
+## Binding decisions this session
+
+### Reshape of guided-entry RFC
+
+- **Dropped** PR 5 (`approvals.chain` + assignments map) and PR 7 (commits-as-signatures, env-var identity). Independent reviewer confirmed no reshape path existed — the accepted RFC's parallel one-file-per-signer model can't host a chain render, and its self-asserted `signer:` field can't be replaced by commit authorship.
+- **Kept + reworked** PRs 1, 2, 3, 4, 6, 8, 9, 10 against accepted-RFC vocabulary.
+- **Ship order (final):** 1 → 2 → 3 → 4 → 8 → 9 → 6 → 10.
+- **Hard dependencies (the only true constraints):** PR 10 must ship last (rewrites every skill's output shape); PR 4 must precede PR 6 (delta section consumes version machinery). Everything else is rollout preference, not coupling.
+
+### Compensating additions (option-b, chosen over option-a)
+
+Three additions to recover most of the multi-role UX lost with PR 5, honoring accepted-RFC constraints:
+
+- **PR 1** — unordered pipe render for active gate: `security ✓ | product ✓ | compliance □`. Honest about the parallel-not-sequential mechanism.
+- **PR 3** — opt-out historical-email heuristic. Matches `git config user.email` against `signer:` fields on past sign-off files. Advisory, labeled "based on past sign-offs," config key `display.session_signoff_hints`. **No role-to-email map introduced in config.**
+- **PR 9** — explicit unordered-parallel callout in glossary + `/help sign-offs`. Prevents users from assuming chain-style ordering that doesn't exist.
+
+### Constraints honored from accepted `multi-team-approval.md`
+
+Guardrails every future PR must respect:
+
+- Signer identity lives in the sign-off file (`signer:` field), never in config
+- No role-to-email map in config
+- No signed-commit enforcement in the plugin (team workflow, outside scope)
+- No tracker-notification-on-signature (would need its own mini-RFC)
+- Sign-offs are parallel, not sequential — no chain rendering in any UX surface
+
+### Second-opinion review findings applied
+
+Commit `d647593` addresses five findings:
+
+1. PR 8 scope note ("Deliberately excluded from Q5–Q8") moved above the question list and inlined at Q5/Q6
+2. Pending A "Small team" preset role list changed from `[product, tech_lead]` to `[product, qa]` (inside the 9-role set); added paragraph pointing Custom users at §3.2 for free-form labels
+3. Ship-order prose softened — separated hard deps from rollout preferences
+4. Dropped unverifiable claims ("smaller than pre-reshape draft," "largest single cognitive-load win")
+5. Added new Open questions section with OQ-1 (PR 4 material-edit detection)
+
+Reviewer verdict: structural reshape sound, vocabulary clean, threat model preserved.
+
+## Open items carried forward
+
+### OQ-1 (now in RFC body, resolve before PR 4 implementation)
+
+PR 4 material-edit detection for `In-scope files`. Proposal: set-change semantics (additions/removals trigger version bump; reordering doesn't).
+
+### Pending discussions (A–E, in RFC body)
+
+- **A.** Workflow templates in `/configure` — **overlaps with scope-ingest note's workflow-template-vs-domain-file question** → resolve A first
+- **B.** Back/cancel navigation in interactive flows
+- **C.** Error-message audit to three-part template
+- **D.** TodoWrite integration for long-running phases
+- **E.** Per-phase checklist rendering in `/status`
+
+### Scope-ingest note conflicts — now unblocked
+
+Reading the accepted RFC resolved all four conflicts listed in `plan-phase-scope-ingest-discussion.md`. Resolutions captured here but **not yet written back to that note** — do it next session before or during the scope-ingest RFC promotion:
+
+1. Sign-off filename → synthetic REQ-ID `REQ-SCOPE-<project-slug>`
+2. Multi-role → default signer is `product`; drop tentative `scope-owner`; domain files declare additional roles for regulated domains
+3. Transport → same ladder as other sign-offs, Tier 0 only for v1
+4. Reconciler → scope gate file at `.claude/sdlc/gates/scope-<project>.md` with `## Required sign-offs` block
+
+Remaining open: treat scope as pseudo-phase gate (cheap) vs. new sign-offable artifact class (cleaner). Defer to scope-ingest RFC promotion.
+
+## Recommended next-session start
+
+**Primary: Pending A — workflow templates vs. domain files unification.**
+
+Why A first:
+
+- Dual-listed in two active threads (PR #1 pending, scope-ingest note)
+- Gates scope-ingest's "decide unification before building seed domain files" next action
+- Contained decision (unify / keep orthogonal / merge indices split content) with three concrete options
+- Shapes downstream vocabulary for two RFCs before any implementation PR opens
+
+If A resolves quickly, next candidates:
+
+1. Write A's resolution back to `plan-phase-scope-ingest-discussion.md`
+2. Mark PR #1 ready-for-review on GitHub (currently draft)
+3. Begin scope-ingest RFC promotion (note → formal RFC)
+
+## Commits this session
+
+- `2e2a085` — reshape guided-entry RFC against accepted multi-team-approval
+- `d647593` — address second-opinion review findings
+
+## Conventions reinforced
+
+- Co-Authored-By: Claude Opus 4.7 trailer on every commit
+- Example identity: `juan.delacruz@acme.com` (matches accepted RFC line 81)
+- Propose edits before making them (doc changes — non-trivial)
+- Second-opinion review after feature design, before implementation
+- Ground every claim in observable repo behavior; no inflated metaphors or unsupported claims
+
+## To resume in a new session
+
+1. Paste `_repo-context.md` first (long-lived grounding)
+2. Paste this file second ("what just happened")
+3. Start with Pending A

--- a/docs/rfcs/notes/_session-handoff.md
+++ b/docs/rfcs/notes/_session-handoff.md
@@ -3,11 +3,11 @@
 > **Status:** current working state (overwritten each session)
 
 **Date:** 2026-04-25
-**Scope:** Key decisions and open items from the two most recent sessions on the guided-entry UX RFC (PR #1) and the scope-ingest discussion note. Complements `_repo-context.md` (long-lived grounding) with short-lived "what just happened" continuity. Overwrite — don't append — when a new session closes.
+**Scope:** Key decisions and open items from three sessions: guided-entry reshape, Pending A resolution, scope-ingest RFC promotion. Complements `_repo-context.md` with short-lived "what just happened" continuity.
 **Related:**
-- [`guided-entry-session-resume-multi-role.md`](../guided-entry-session-resume-multi-role.md) — main RFC, all pending discussions now resolved or deferred
-- [`multi-team-approval.md`](../multi-team-approval.md) — accepted RFC; constraints honored throughout
-- [`plan-phase-scope-ingest-discussion.md`](./plan-phase-scope-ingest-discussion.md) — all conflicts resolved; ready for RFC promotion
+- [`guided-entry-session-resume-multi-role.md`](../guided-entry-session-resume-multi-role.md) — main RFC, all pending discussions resolved or deferred; PR #1 marked ready for review
+- [`scope-ingest.md`](../scope-ingest.md) — formal RFC draft as of 2026-04-25
+- [`multi-team-approval.md`](../multi-team-approval.md) — accepted RFC; all constraints honored
 - PR #1: https://github.com/lantisprime/claude-sdlc/pull/1
 
 ---
@@ -16,97 +16,95 @@
 
 ### Reshape of guided-entry RFC (2026-04-24)
 
-- **Dropped** PR 5 (`approvals.chain` + assignments map) and PR 7 (commits-as-signatures, env-var identity). Independent reviewer confirmed no reshape path existed — the accepted RFC's parallel one-file-per-signer model can't host a chain render, and its self-asserted `signer:` field can't be replaced by commit authorship.
-- **Kept + reworked** PRs 1, 2, 3, 4, 6, 8, 9, 10 against accepted-RFC vocabulary.
-- **Ship order (final):** 1 → 2 → 3 → 4 → 8 → 9 → 6 → 10.
-- **Hard dependencies:** PR 10 must ship last (rewrites every skill's output shape); PR 4 must precede PR 6 (delta section consumes version machinery). Everything else is rollout preference.
+- **Dropped** PR 5 and PR 7 — accepted RFC's model can't host them.
+- **Kept + reworked** PRs 1, 2, 3, 4, 6, 8, 9, 10.
+- **Ship order:** 1 → 2 → 3 → 4 → 8 → 9 → 6 → 10. Hard deps: PR 10 last, PR 4 before PR 6.
+- **Compensating additions (option-b):** PR 1 unordered pipe render, PR 3 historical-email heuristic, PR 9 unordered-parallel callout.
 
-### Compensating additions (option-b, 2026-04-24)
+### Pending A: workflow templates vs. domain files — keep orthogonal (2026-04-25)
 
-- **PR 1** — unordered pipe render: `security ✓ | product ✓ | compliance □`. Honest about the parallel-not-sequential mechanism.
-- **PR 3** — opt-out historical-email heuristic. Matches `git config user.email` against `signer:` on past sign-off files. Advisory, labeled "based on past sign-offs," config key `display.session_signoff_hints`. No role-to-email map in config.
-- **PR 9** — explicit unordered-parallel callout in glossary + `/help sign-offs`.
+Workflow presets (PR #1 §A, `/configure` Q5) = pure config. Domain files (`domains/payments.md`) = pure knowledge. Advisory bridge: optional `suggested_roles: []` in domain file frontmatter; plan skill surfaces it but does not enforce. Written back to scope-ingest note, guided-entry RFC, and `_repo-context.md`.
 
-### Pending A resolved: workflow templates vs. domain files (2026-04-25)
+### Scope-ingest conflict resolutions — written back (2026-04-25)
 
-**Decision: keep orthogonal.**
+All four conflicts with `multi-team-approval.md` resolved in scope-ingest note and carried into the formal RFC:
+1. Sign-off filename → `REQ-SCOPE-<project-slug>`, file `sign-offs/REQ-SCOPE-<slug>-product.md`
+2. Default signer → `product`; drop `scope-owner`; `suggested_roles` advisory only
+3. Transport → Tier 0 for v1; same config keys as phase sign-offs
+4. Reconciler → scope gate at `.claude/sdlc/gates/scope-<project>.md` with `## Required sign-offs` block
 
-- **Workflow presets** (PR #1 §A, `/configure` Q5) = pure config: `approvals.roles` + transport defaults. Answer "how does your team manage sign-offs?"
-- **Domain files** (`domains/payments.md` etc.) = pure knowledge: glossary, NFRs, regulatory concerns, gap questions. Answer "what domain-specific constraints apply?"
-- **Advisory bridge:** domain file schema gains optional `suggested_roles: []`. Plan skill surfaces it at plan-time as context; does not enforce or override `approvals.roles`. Absent and empty list are equivalent.
-- Both artifacts have separate owners and evolve independently. No coordination gate going forward.
+### Scope-ingest RFC promoted (2026-04-25)
 
-Written back to: scope-ingest note (open question resolved, schema updated), guided-entry RFC (Pending A section), `_repo-context.md` (PR #1 entry).
+`docs/rfcs/notes/plan-phase-scope-ingest-discussion.md` → `docs/rfcs/scope-ingest.md`.
 
-### Scope-ingest conflict resolutions (2026-04-24, written back 2026-04-25)
+RFC contents:
+- `scope-ingest` agent (narrow write scope: `scope-drafts/` only; provenance-traced)
+- `domain-expert` skill (read-and-inject; `domains/` directory; `suggested_roles` advisory bridge)
+- Modified `/plan` flow (6 steps; user surface unchanged)
+- All sign-off alignment resolved
+- `domains/_schema.md` + seed files (`payments.md`, `auth.md`) specified
+- OQ-SCOPE-1 open: pseudo-phase gate vs. new artifact class (see §6)
+- 14-item implementation checklist
 
-All four conflicts against `multi-team-approval.md` now recorded in `plan-phase-scope-ingest-discussion.md`:
+Discussion note status: `superseded (promoted)`.
 
-1. Sign-off filename → synthetic REQ-ID `REQ-SCOPE-<project-slug>`; file: `sign-offs/REQ-SCOPE-<slug>-product.md`
-2. Default signer role → `product`; drop tentative `scope-owner`; domain files may declare `suggested_roles` for regulated domains
-3. Transport → same ladder as other sign-offs, Tier 0 only for v1
-4. Reconciler → scope gate file at `.claude/sdlc/gates/scope-<project>.md` with `## Required sign-offs` block; pseudo-phase gate model
+### PR #1 ready-for-review (2026-04-25)
+
+Marked ready via `gh pr ready 1`. No longer draft.
 
 ### Constraints honored from accepted `multi-team-approval.md`
 
-- Signer identity lives in the sign-off file (`signer:` field), never in config
+- Signer identity in sign-off file (`signer:`), never in config
 - No role-to-email map in config
-- No signed-commit enforcement in the plugin
+- No signed-commit enforcement
 - No tracker-notification-on-signature
-- Sign-offs are parallel, not sequential — no chain rendering
+- Sign-offs are parallel, not sequential
 
 ---
 
 ## Open items carried forward
 
-### OQ-1 (in RFC body, resolve before PR 4 implementation)
+### OQ-SCOPE-1 (resolve before scope-ingest implementation begins)
+
+Pseudo-phase gate vs. new artifact class for `.claude/sdlc/gates/scope-<project>.md`. Proposal: ship v1 as pseudo-phase gate (low cost; upgrade path is a rename + registry entry if confusion causes operator errors). Answer pending.
+
+### OQ-1 in guided-entry RFC (resolve before PR 4 implementation)
 
 PR 4 material-edit detection for `In-scope files`. Proposal: set-change semantics (additions/removals trigger version bump; reordering doesn't).
 
-### Pending B–E (in RFC body, deferred)
+### Pending B–E in guided-entry RFC (deferred)
 
-- **B.** Back/cancel navigation in interactive flows
-- **C.** Error-message audit to three-part template
-- **D.** TodoWrite integration for long-running phases
-- **E.** Per-phase checklist rendering in `/status`
-
-### Scope-ingest RFC promotion
-
-`plan-phase-scope-ingest-discussion.md` is now unblocked:
-- All 4 accepted-RFC conflicts resolved and written back
-- Pending A coordination gate lifted
-- One remaining open: pseudo-phase-gate vs. new artifact class for scope (deferred to promotion)
-- Next: draft `docs/rfcs/scope-ingest.md`
+B. Back/cancel navigation, C. Error-message audit, D. TodoWrite integration, E. Per-phase `/status` detail.
 
 ---
 
 ## Recommended next-session start
 
-**Primary: mark PR #1 ready-for-review on GitHub** (currently draft).
+**Primary: resolve OQ-SCOPE-1** (pseudo-phase gate vs. artifact class) before the scope-ingest implementation checklist can begin.
 
-Why now: all blocking conflicts resolved (reshape 2026-04-24, Pending A 2026-04-25). OQ-1 and Pending B–E are deferrable post-merge questions.
+Why first: it's a contained yes/no with a clear proposal already in RFC §6. Resolving it unblocks the entire 14-item implementation checklist.
 
-If that's quick, next candidates:
-1. Begin scope-ingest RFC promotion: draft `docs/rfcs/scope-ingest.md` from the discussion note
-2. Resolve OQ-1 (PR 4 material-edit detection) before implementation begins
+After OQ-SCOPE-1:
+1. Begin scope-ingest implementation — `domains/_schema.md` and seed files are the cheapest first step per §14 checklist
+2. Resolve OQ-1 (guided-entry PR 4) before its implementation begins
 
 ---
 
 ## Commits this session
 
-- `0ca09ff` — docs(notes): add session handoff for next-session pickup
+- `ba39520` — docs(rfc): resolve Pending A, write back scope-ingest conflicts
 - *(current session commit pending)*
 
 ## Conventions reinforced
 
 - Co-Authored-By: Claude Opus 4.7 trailer on every commit
-- Example identity: `juan.delacruz@acme.com` (matches accepted RFC line 81)
-- Propose edits before making them (doc changes — non-trivial); skip on explicit "go"
+- Example identity: `juan.delacruz@acme.com`
+- Propose doc edits before making them; skip on explicit "go"
 - Second-opinion review after feature design, before implementation
 - Ground every claim in observable repo behavior
 
 ## To resume in a new session
 
-1. Paste `_repo-context.md` first (long-lived grounding)
-2. Paste this file second ("what just happened")
-3. Mark PR #1 ready-for-review, then begin scope-ingest RFC promotion
+1. Paste `_repo-context.md` first
+2. Paste this file second
+3. Start with OQ-SCOPE-1 — read RFC §6, confirm or replace the proposal

--- a/docs/rfcs/notes/guided-entry-pr7-degradation.md
+++ b/docs/rfcs/notes/guided-entry-pr7-degradation.md
@@ -1,0 +1,242 @@
+# PR 7 — Distributed Sign-Off: Degradation and Failure Modes
+
+**Companion to:** RFC 0001
+**Scope:** Implementation reference for `skills/gate-signoff/SKILL.md` and `templates/gate.md` changes in PR 7.
+
+This note exists because PR 7's "graceful degradation" story is more nuanced than PR 5's. PR 5 had a single fallback: config absent means current behavior. PR 7 has multiple layers that can be present, misconfigured, or missing, and each requires a different correct response. Some degrade, some hand off, some intentionally refuse. Implementers should read this before writing the skill changes.
+
+---
+
+## The layers that can fail
+
+PR 7 depends on a chain of assumptions. Any link can be missing:
+
+| Layer | Required for | If missing |
+|---|---|---|
+| Git installed | Everything | Plugin already unusable — hard dependency of the repo |
+| Inside a git repo | Commits, audit trail | Hand off to PR 5 |
+| Git config `user.email` | Identity resolution | Try env var; if also missing, see identity rules below |
+| `CLAUDE_SDLC_APPROVER_IDENTITY` env var | Identity override | Fall through to git config |
+| `approvals.assignments` map | Role verification | Capture with `role_verified: false` |
+| Remote configured | Distributing signatures | Commit locally, print push-later guidance |
+| Push access to branch | Sharing signatures | Commit stands; human pushes via PR |
+| `git commit -S` signing key | Opt-in cryptographic authorship | Sign unsigned, flag it |
+
+---
+
+## Decision tree
+
+```
+gate-signoff invoked
+│
+├─ Is this a git repo?
+│    ├─ NO  → hand off: "Distributed sign-off requires git. Falling back
+│    │        to in-session multi-role (PR 5). All approvers must sign
+│    │        in this session."
+│    └─ YES → continue
+│
+├─ Can we resolve signer identity?
+│    │  (check env var CLAUDE_SDLC_APPROVER_IDENTITY,
+│    │   then `git config user.email`)
+│    │
+│    ├─ NO  → is `approvals.assignments` configured?
+│    │        ├─ NO  → DEGRADE: capture signature, set role_verified=false
+│    │        └─ YES → REFUSE: "Cannot verify you are assigned to this
+│    │                 role. Set git config user.email or
+│    │                 CLAUDE_SDLC_APPROVER_IDENTITY, or ask the
+│    │                 assigned approver to sign."
+│    │
+│    └─ YES → does identity match assignment for this role?
+│              ├─ NO  → REFUSE: "Signing as '<role>' requires
+│              │         '<assigned>'; got '<resolved>'."
+│              └─ YES → continue
+│
+├─ Write signature block to gate file
+│
+├─ Auto-commit enabled? (config: approvals.auto_commit, default false)
+│    ├─ YES → git add + git commit
+│    └─ NO  → prompt: "Commit this signature now? [Y/n]"
+│
+├─ Is `git commit -S` requested? (config: approvals.require_signed_commits)
+│    ├─ YES → attempt signed commit
+│    │         ├─ SUCCESS → record commit_signed=true in gate block
+│    │         └─ FAIL (no key)    → commit unsigned, record
+│    │                                commit_signed=false, print warning
+│    └─ NO  → regular commit, commit_signed field omitted
+│
+├─ Is there a remote configured?
+│    ├─ NO  → print: "Signature committed locally. No remote configured;
+│    │        share this branch manually."
+│    └─ YES → attempt git push
+│              ├─ SUCCESS            → "Signature pushed. Next approver
+│              │                        can pull branch <name>."
+│              ├─ REJECTED (protection) → "Signature committed locally
+│              │                          to <branch>. Push rejected by
+│              │                          branch protection. Open a PR."
+│              └─ FAIL (network etc.) → "Signature committed locally.
+│                                       Push failed: <reason>.
+│                                       Try again later."
+```
+
+---
+
+## Refuse vs. degrade vs. hand-off — the three response types
+
+### Refuse
+
+The plugin stops and prints a clear error. Used when continuing would violate the feature's purpose.
+
+- Identity unresolvable *and* `assignments` is configured — degrading here would defeat having assignments at all
+- Identity resolves but doesn't match the assigned role — the whole point of assignment checking
+
+Refusal is not a gap or a missing feature. It is the feature doing its job. The RFC and user-facing docs should be explicit about this.
+
+### Degrade
+
+The plugin captures what it can and records the gap in the signature itself. Downstream reviewers can see the degradation and decide whether it's acceptable.
+
+- Identity unresolvable *and* `assignments` absent → `role_verified: false`
+- `git commit -S` requested but key missing → `commit_signed: false`
+- No remote → local commit only, with a note
+
+Degradation requires that the gap be visible in the gate file. Silent degradation is worse than refusal because it launders weak signals as strong ones.
+
+### Hand off
+
+The plugin explicitly tells the user "this isn't the right mode for your environment" and falls back to an adjacent feature.
+
+- Not in a git repo → use PR 5 in-session multi-role
+
+Hand-off is used when the prerequisites for PR 7 aren't met but another working path exists. Print the message so the user knows why the behavior changed.
+
+---
+
+## Test matrix
+
+Each row should have at least one integration test before merging PR 7.
+
+| Scenario | Expected behavior | Gate block state |
+|---|---|---|
+| Happy path: all layers present, identity matches | Sign, commit, push, all roles verified | `role_verified: true, commit_signed: false` |
+| Happy path with GPG signing | As above, signed commit | `role_verified: true, commit_signed: true` |
+| Not a git repo | Hand off to PR 5 | N/A (PR 5 format) |
+| Git repo, no remote | Local commit, push-later message | `role_verified: true` |
+| Git repo, remote exists, push rejected by branch protection | Local commit stands, PR-suggestion message | `role_verified: true` |
+| No git config, no env var, no assignments | Capture with flag | `role_verified: false` |
+| No git config, no env var, assignments present | Refuse | No gate block written |
+| Identity resolved, wrong role | Refuse | No gate block written |
+| Identity resolved, role matches, but chain already has this role signed | Skip to next unsigned role | Existing block untouched |
+| All roles already signed | No-op, print "Already signed" | Existing blocks untouched |
+| Partial gate file from prior session, signer is next in chain | Append only their block | Prior blocks untouched, new block added |
+| Rebase-induced conflict on gate file | Each signature block is a separate hunk; normal git merge handles it | All blocks preserved |
+| Two approvers sign on parallel branches, then merge | Both signature blocks land as independent hunks; merge produces a valid gate file | Both blocks preserved, no conflict |
+| Tracker notification fails (offline, no token, 4xx/5xx) | Signature lands; local print fallback; gate block flags the gap | `role_verified: true, notification_sent: false` |
+| `commit -S` requested, no GPG key | Unsigned commit, warning printed | `role_verified: true, commit_signed: false` |
+| `commit -S` requested, GPG key present, keyring trust fails | Treat as success from plugin's POV; trust verification is the team's workflow | `role_verified: true, commit_signed: true` |
+
+---
+
+## Gate file format implications
+
+For rebase-friendly and append-only behavior, signature blocks must be independent. Proposed shape:
+
+```markdown
+# Gate: build-rate-limit-headers
+
+Plan version: 2
+Status: awaiting-approvals
+
+## Signatures
+
+<!-- @@SIGNATURE tech_lead @@ -->
+- Role: tech_lead
+- Signer: alice@acme.com (resolved from git config)
+- role_verified: true
+- Work item: https://linear.app/acme/issue/PROJ-1234
+- Acknowledgment: "https://linear.app/acme/issue/PROJ-1234"
+- Signed at: 2026-04-22T10:15:00Z
+- commit_signed: false
+- notification_sent: true
+<!-- @@END SIGNATURE tech_lead @@ -->
+
+<!-- @@SIGNATURE architect @@ -->
+- Role: architect
+- Signer: bob@acme.com (resolved from git config)
+- role_verified: true
+- Work item: https://linear.app/acme/issue/PROJ-1234
+- Acknowledgment: "https://linear.app/acme/issue/PROJ-1234"
+- Signed at: 2026-04-22T10:18:00Z
+- commit_signed: true
+- notification_sent: true
+<!-- @@END SIGNATURE architect @@ -->
+```
+
+The `@@SIGNATURE <role> @@` markers let the skill find, skip, or append blocks without full markdown parsing. Each block is self-contained so concurrent edits on different branches produce clean merges rather than structural conflicts.
+
+---
+
+## User-facing messages
+
+Every refuse and degrade path needs a message that tells the user (a) what happened, (b) why, and (c) what to do next. Templates for the core cases:
+
+**Refuse — identity unresolvable with assignments configured:**
+```
+Cannot verify you are assigned to role '<role>'.
+Neither git config user.email nor CLAUDE_SDLC_APPROVER_IDENTITY
+is set. Options:
+  1. Run: git config --global user.email "you@example.com"
+  2. Set: export CLAUDE_SDLC_APPROVER_IDENTITY="you@example.com"
+  3. Ask the assigned approver '<assigned>' to sign instead.
+```
+
+**Refuse — identity mismatch:**
+```
+Signing as '<role>' requires identity '<assigned>'.
+Your git identity is '<resolved>'.
+If you are the correct approver, update your git config.
+If you are not, the assigned approver must sign instead.
+```
+
+**Degrade — no assignments, no identity:**
+```
+Signature captured without identity verification.
+Gate will record role_verified: false.
+Reviewers can decide whether this signature is acceptable.
+```
+
+**Hand off — not a git repo:**
+```
+Distributed sign-off requires git.
+This directory is not a git repo. Falling back to in-session
+multi-role sign-off. All approvers must be present in this
+session to sign in sequence.
+```
+
+**Degrade — no remote:**
+```
+Signature committed locally (<commit sha>).
+No remote is configured. Share this branch with the next
+approver manually, or push once a remote is added.
+Next approver: <role> — <assigned>.
+```
+
+**Degrade — push rejected by branch protection:**
+```
+Signature committed locally to branch '<branch>' (<commit sha>).
+Push was rejected by branch protection.
+Open a pull request to land the signature:
+  gh pr create --base main --head <branch>
+```
+
+---
+
+## What this note does not cover
+
+- Appeal paths, reviewer-of-reviewers, retrospective audits — deferred per RFC
+- Cryptographic key management and keyring distribution — team workflow, not plugin concern
+- Merge conflict resolution when two signers race — git handles structurally; the block format prevents content conflicts
+- Revocation of a signature after the fact — git revert plus a new version per PR 4 is the current answer
+
+---
+
+*End of note.*

--- a/docs/rfcs/notes/guided-entry-pr7-degradation.md
+++ b/docs/rfcs/notes/guided-entry-pr7-degradation.md
@@ -1,7 +1,17 @@
 # PR 7 — Distributed Sign-Off: Degradation and Failure Modes
 
-**Companion to:** RFC 0001
-**Scope:** Implementation reference for `skills/gate-signoff/SKILL.md` and `templates/gate.md` changes in PR 7.
+> **Status:** superseded (2026-04-24)
+
+**Companion to:** formerly RFC 0001 PR 7 (dropped during reshape)
+**Scope (historical):** Implementation reference for `skills/gate-signoff/SKILL.md` and `templates/gate.md` changes that were proposed for PR 7.
+
+**Superseded by:** [multi-team-approval.md](../multi-team-approval.md). PR 7 was dropped during the guided-entry RFC's reshape on 2026-04-24. The accepted multi-team-approval RFC handles distributed sign-off via a different mechanism — **file transports**, not commits-as-signatures. See accepted RFC §3.4 (transport ladder, with Tier 2 carrying sign-off files through a central git repo), §3.5 (`APPROVALS.md` projection), and §3.6 (identity model — external tools are file-drop transports, not signature sources).
+
+This note is kept for historical reference. Some of the failure-mode analysis below may still be useful when implementing the accepted RFC's Tier 2 git transport, which has overlapping failure modes (no remote, push rejection, branch protection) even though the *artifact* being moved is different (a sign-off file in `sign-offs/`, not the gate file itself with embedded signature blocks). Treat this document as background, not spec.
+
+---
+
+## Original note content follows
 
 This note exists because PR 7's "graceful degradation" story is more nuanced than PR 5's. PR 5 had a single fallback: config absent means current behavior. PR 7 has multiple layers that can be present, misconfigured, or missing, and each requires a different correct response. Some degrade, some hand off, some intentionally refuse. Implementers should read this before writing the skill changes.
 
@@ -150,7 +160,7 @@ Status: awaiting-approvals
 
 <!-- @@SIGNATURE tech_lead @@ -->
 - Role: tech_lead
-- Signer: alice@acme.com (resolved from git config)
+- Signer: juan.delacruz@acme.com (resolved from git config)
 - role_verified: true
 - Work item: https://linear.app/acme/issue/PROJ-1234
 - Acknowledgment: "https://linear.app/acme/issue/PROJ-1234"
@@ -161,7 +171,7 @@ Status: awaiting-approvals
 
 <!-- @@SIGNATURE architect @@ -->
 - Role: architect
-- Signer: bob@acme.com (resolved from git config)
+- Signer: maria.santos@acme.com (resolved from git config)
 - role_verified: true
 - Work item: https://linear.app/acme/issue/PROJ-1234
 - Acknowledgment: "https://linear.app/acme/issue/PROJ-1234"

--- a/docs/rfcs/notes/plan-phase-scope-ingest-discussion.md
+++ b/docs/rfcs/notes/plan-phase-scope-ingest-discussion.md
@@ -1,12 +1,14 @@
 # Plan phase — scope ingest + domain expert discussion
 
-> **Status:** discussion note. Not an RFC, not accepted. Captures current thinking on reshaping Phase 1 to reduce cognitive load around scope authoring and introduce domain-aware plan validation.
+> **Status:** superseded (promoted 2026-04-25)
+
+**Promoted to:** [`docs/rfcs/scope-ingest.md`](../scope-ingest.md) — formal RFC draft as of 2026-04-25. All four accepted-RFC conflicts resolved; Pending A coordination gate lifted. This note is kept as a historical record of the analysis path.
 
 **Date:** 2026-04-24
 **Scope:** Phase 1 (`/plan`) only. Skill-count audit explicitly deferred.
 **Related:**
 - `docs/rfcs/multi-team-approval.md` (accepted 2026-04-19) — sign-off conventions this proposal must conform to
-- PR #1 *Guided-entry UX RFC (draft)* — overlapping "reduce cognitive load" thesis, pending Path A reshape
+- PR #1 *Guided-entry UX RFC (draft)* — overlapping "reduce cognitive load" thesis, Pending A resolved 2026-04-25
 
 ---
 

--- a/docs/rfcs/notes/plan-phase-scope-ingest-discussion.md
+++ b/docs/rfcs/notes/plan-phase-scope-ingest-discussion.md
@@ -1,0 +1,235 @@
+# Plan phase — scope ingest + domain expert discussion
+
+> **Status:** discussion note. Not an RFC, not accepted. Captures current thinking on reshaping Phase 1 to reduce cognitive load around scope authoring and introduce domain-aware plan validation.
+
+**Date:** 2026-04-24
+**Scope:** Phase 1 (`/plan`) only. Skill-count audit explicitly deferred.
+**Related:**
+- `docs/rfcs/multi-team-approval.md` (accepted 2026-04-19) — sign-off conventions this proposal must conform to
+- PR #1 *Guided-entry UX RFC (draft)* — overlapping "reduce cognitive load" thesis, pending Path A reshape
+
+---
+
+## Problem
+
+`scope.md` today is authored by the human at first `/plan` invocation. Three failure modes compound:
+
+1. **Format sprawl.** Real-world scope lives in PDFs, Word docs, PPTX briefs, Confluence pages, Notion, Jira epics. Today the human has to translate any of those into a one-paragraph chat statement or a hand-written markdown file.
+2. **Quality uncertainty.** There's no validation that `scope.md` is clear, complete, or aligned with domain-specific regulations. The plan skill reads it and trusts it.
+3. **Cognitive load.** Open-ended authoring ("write the scope statement") is higher-load than closed-form answering ("answer these 4 specific questions"). The plugin's own design philosophy — reduce surprise, reduce friction at the expensive moments — applies to scope too.
+
+`scope.md` is the constitution every downstream phase validates against. Getting it wrong silently widens what the plugin permits for months. The failure cascades.
+
+## What can't change
+
+- **The human still signs the final scope.** Auto-generating without a signature breaks "human in the lead." The signature is the expensive, non-delegable act.
+- **`scope.md` stays the canonical artifact.** Downstream phases already read it; changing the file path would ripple.
+- **Graceful degradation.** Any new path must fall back cleanly when no source is available, same as the rest of the plugin.
+
+## Proposed approach
+
+Two new capabilities, both invoked internally by the existing `/plan` command. No new user-facing commands.
+
+### 1. `scope-ingest` agent
+
+Bounded subprocess with narrow write scope (`scope.md` and `scope-drafts/` only). Handles the expensive, messy work of turning source material into a normalized scope draft.
+
+**Accepts:**
+- File paths: `.md`, `.txt`, `.pdf`, `.docx`, `.pptx`
+- URLs (with the honest caveat that auth-walled sources require the human to paste exported content)
+- Ticket references (if Jira/Linear MCP is wired)
+- Raw chat text
+- An existing `scope.md` (re-validate mode — reads, reports drift, does not rewrite)
+
+**Pipeline:**
+1. Parse to plain-text blocks with provenance (source, page/section, line span)
+2. Normalize into a fixed schema: `project_name`, `domain`, `in_scope[]`, `out_of_scope[]`, `success_criteria`, `constraints[]`, `stakeholders`, `assumptions`. Absent fields stay absent — no fabrication.
+3. Emit a draft at `.claude/sdlc/scope-drafts/<timestamp>.md` with per-bullet provenance footer.
+4. Return to plan skill: draft path + extraction confidence per field.
+
+**Explicit non-goals:** writing `scope.md` directly, signing anything, deciding domain, fabricating missing fields.
+
+**Why agent, not skill:** ingesting a 50-page PDF is expensive; bounding it to a subprocess keeps main-turn tokens sane. Narrow write scope is a real safety property, not cosmetic.
+
+### 2. `domain-expert` skill
+
+Read-and-inject pattern. Lightweight. Invoked by `/plan` now, reusable by `/analyze` and `/design` later.
+
+**New directory at plugin root:**
+```
+domains/
+├── _index.json          # keyword + stack → domain slug
+├── _schema.md           # required shape for domain files
+├── payments.md          # seed
+├── auth.md              # seed
+└── ...
+```
+
+**Domain file shape:**
+```
+---
+slug: payments
+last_reviewed: 2026-03-15
+owner: <team-or-person>
+---
+# Payments
+
+## Glossary
+## Typical NFRs
+## Regulatory concerns
+## Common pitfalls
+## Stack notes
+## Security hotspots
+## Scope must address
+## Questions plan must answer
+```
+
+The `last_reviewed` + `owner` frontmatter is load-bearing — without it, domain files rot silently.
+
+**Matching logic (3-tier, in order):**
+1. Explicit `domain:` tag in `scope.md` frontmatter → authoritative
+2. Rule match against `domains/_index.json` → confidence `high` / `medium` / `low`
+3. No match → `domain: unknown`, proceed without injection
+
+Low-confidence matches force human confirmation at the plan gate. No silent assignment.
+
+**Output:** a `## Domain context` section injected into the plan artifact containing matched domain, confidence, unanswered `Questions plan must answer`, and `Scope must address` items the scope doesn't yet cover.
+
+### 3. Modified `/plan` flow
+
+6 steps instead of 5:
+
+1. Classify work item *(unchanged)*
+2. **Resolve scope** — if `scope.md` exists and is signed, read it. Otherwise invoke `scope-ingest` with whatever source the human points at. No source → prompt for one-paragraph statement (current fallback).
+3. **Detect and load domain** — `domain-expert` reads problem + stack + scope, matches, produces gap questions.
+4. Write plan artifact, including `## Domain context` section *(new)*
+5. Record tech stack + compatibility matrix *(unchanged)*
+6. Human gate — sign-off covers plan + domain confirmation
+
+User sees same `/plan` command, same gate ritual. What changes is the quality of what lands in `scope.md` and the depth of the plan artifact.
+
+### Cognitive load — honest accounting
+
+**First `/plan` in a new repo (increases slightly):**
+1. Point at a source (path, URL, or paste text)
+2. Answer gap questions (closed-form, not open-ended)
+3. Sign scope — new one-time step
+4. Confirm domain if confidence isn't high
+5. Sign plan gate — existing
+
+**Subsequent `/plan` runs (roughly unchanged):**
+1. Run `/plan "<task>"`
+2. Confirm domain if confidence isn't high
+3. Sign plan gate
+
+The load reduction isn't "Claude writes it for you." It's **load shifting from open-ended authoring to closed-form answering.** Don't oversell it — first-time setup gets marginally heavier in exchange for better scope quality from day one.
+
+---
+
+## Conflict analysis — against accepted RFC and PR #1
+
+### Direct conflicts with `multi-team-approval.md` (accepted)
+
+**1. Sign-off filename convention.** Earlier draft of this proposal used `sign-offs/scope-<date>.md`. Accepted RFC uses `sign-offs/<REQ-ID>-<role>.md`. These don't align:
+- Scope isn't tied to a REQ-ID (it's upstream of requirements)
+- Scope may not have a single role signer
+
+**Reshape:** either assign a synthetic REQ-ID (e.g., `REQ-SCOPE-<project>`) or carve out a named exception. Don't silently invent a parallel pattern — that's exactly the drift the accepted RFC prevents.
+
+**2. Single-signer assumption.** Proposal wrote "human signs scope" in the singular. With the 9-role set and multi-team approval as accepted policy, certain domains probably need multi-role scope sign-off (payments: product + compliance + security). Current position: default single-role, with domain files declaring when multi-role is required. Needs the 9-role list to resolve.
+
+**3. Transport ladder.** Proposal assumed chat sign-off as default. Accepted RFC defines Tiers 0–3. Can't say which tier scope sign-off belongs to without reading the ladder. Deferred.
+
+**4. `APPROVALS.md` reconciler.** Proposal didn't mention it. Scope sign-off output needs to emit something the reconciler can parse. Format constraint unresolved.
+
+### Overlaps with PR #1 (draft)
+
+**1. Shared thesis — reduce cognitive load.** PR #1 comes at it from session/navigation angle (guided entry, session resume, back/cancel, error messages, `/status` detail). This proposal comes from the authoring/validation angle (ingest, domain validation, gap-report vs. blank-page). Both legitimate, not conflicting, but need coordination.
+
+**2. Pending discussion A — workflow templates (per-task-type starters).** Conceptually close to domain files. Different framing — templates are per-task-type; domain files are per-domain — but a world exists where they're the same artifact. Worth asking before shipping whether they should merge.
+
+**3. Pending discussion D — TodoWrite integration.** If long-running phases start using TodoWrite, `scope-ingest` (long-running on large PDFs) should participate in the same pattern.
+
+**4. PR #1 PRs 1, 2, 3, 4, 6, 8, 9, 10** — contents not fetched from draft branch; any could touch Phase 1 UX. Unknown until read.
+
+### What's clearly complementary (no conflict)
+
+Untouched by either RFC:
+- Multi-format ingestion
+- Normalization schema + provenance
+- `domains/` directory and matching logic
+- `## Domain context` injection into plan artifact
+- Gap-report-not-draft pattern
+- Modifying plan Steps 2–3 internally
+- `scope-ingest` as an agent
+
+### What I can't see from outside the repo
+
+Explicit: this analysis is partial without these.
+
+1. Full text of `multi-team-approval.md` — needed to resolve sign-off filename, role assignment, transport tier, reconciler format.
+2. The 10-PR contents in PR #1 — unknown overlap surface.
+3. The 9-role set — determines scope sign-off role(s).
+
+---
+
+## Open questions / deferred
+
+- **Domain file curation process.** Who owns `domains/payments.md`? How are updates reviewed? Same discipline as skills, or lighter? Decide later.
+- **Scope regeneration policy.** When the source PDF updates to v4, what happens? Options: ignore / `/plan --refresh-scope` / warn on drift. Ship v1 without regeneration; observe.
+- **Multi-domain matching.** v1 matches top-1 domain; human can override to multi. v2 could auto-match multi. Don't build upfront.
+- **Workflow templates vs. domain files** (from PR #1 pending A). Unify or keep orthogonal. Decide before shipping domain-expert.
+- **Sign-off role naming.** Tentative "scope-owner"; waits on 9-role set confirmation.
+
+---
+
+## Architectural decisions and tradeoffs
+
+- **Agent for `scope-ingest`, skill for `domain-expert`.** Agent when bounded write scope + expensive isolated work justify the subprocess cost. Skill when it's a reusable read-and-inject pattern across phases. Converting everything to agents would increase token cost and reduce traceability.
+- **No new commands.** Cognitive load lives at the command level, not the skill level. `/plan` stays the single entry point. Both capabilities hang off it internally.
+- **`scope.md` is a derived, validated artifact — not an authoring target.** This reframe is load-bearing. It's what lets us accept any source format: the human points at source material, the plugin derives, the human validates and signs.
+- **Gap report, not draft.** A draft invites rubber-stamping. A gap report forces targeted answers. This is the actual cognitive load reduction mechanism.
+- **Provenance footer required.** Every scope bullet traces to its source span. Without this, LLM fabrication in the normalization step is undetectable at sign-off.
+
+---
+
+## Failure modes to guard against
+
+- **Domain files too generic.** "Payments" covers too much → gap questions become noise → humans ignore → no value delivered. Start narrow; expand based on observed gaps.
+- **Over-aggressive ingestion.** Fabricating scope from thin sources → subtly wrong signed scope → every downstream phase drifts. Mitigation: per-bullet provenance, source-next-to-extracted-bullet view before signing.
+- **Onerous first-time setup.** If scope ingest + domain validation makes greenfield setup painful, teams skip the plugin. Mitigation: minimum-viable one-paragraph scope remains acceptable; gap questions are advisory unless domain file marks them `required`.
+- **Stale domain files.** `last_reviewed` frontmatter required; owner required; treat as living docs.
+- **Wrong domain match.** Wrong checklist → wrong gaps → misleading scope. Low-confidence matches must force human confirmation, not silently proceed.
+
+---
+
+## Suggested sequencing
+
+1. **Wait on accepted-RFC vocabulary** before implementing the sign-off portion. Non-sign-off parts safe to prototype now.
+2. **Write the domain file schema** (`domains/_schema.md`) + one seed file (`domains/payments.md`). Cheapest piece; validates shape before building consumers.
+3. **Build `domain-expert` skill.** Needs only schema + index. Testable standalone against synthetic plan inputs.
+4. **Build `scope-ingest` agent** — markdown + PDF parsers first; DOCX/PPTX/URL in a follow-up. Honest scoping.
+5. **Modify `plan` skill** — wire in Step 2 (scope-ingest invocation) and Step 3 (domain-expert injection).
+6. **Resolve sign-off alignment** once the accepted RFC's vocabulary is in hand. Rename artifact, pick role(s), emit reconciler-compatible output.
+7. **Dry-run on 3–5 past plan artifacts.** Does the new flow produce better plans on real past work? If not, the domain files are wrong, not the architecture.
+8. **Documentation pass** — README "Scope setup" section; `docs/SDLC.md` Phase 1 update.
+
+---
+
+## What would make this fail
+
+Named so future reviewers can check:
+
+- Shipping scope-ingest without the provenance footer (fabrication goes undetected)
+- Shipping domain-expert with broad/vague seed domain files (gap questions become noise)
+- Bypassing the accepted sign-off convention "just for scope" (drift that compounds)
+- Adding `/scope` or similar commands (defeats the no-new-commands constraint)
+- Treating the first-time-setup load increase as free (it's real; name it honestly in docs)
+
+---
+
+## Next actions
+
+- Decide on workflow-templates-vs-domain-files unification before building seed domain files (coordinate with PR #1 pending A)
+- Read `multi-team-approval.md` in full; update this note's conflict section
+- Read PR #1's RFC body in full; update overlap section

--- a/docs/rfcs/notes/plan-phase-scope-ingest-discussion.md
+++ b/docs/rfcs/notes/plan-phase-scope-ingest-discussion.md
@@ -71,6 +71,7 @@ domains/
 slug: payments
 last_reviewed: 2026-03-15
 owner: <team-or-person>
+suggested_roles: []
 ---
 # Payments
 
@@ -85,6 +86,8 @@ owner: <team-or-person>
 ```
 
 The `last_reviewed` + `owner` frontmatter is load-bearing — without it, domain files rot silently.
+
+The `suggested_roles` field is optional. When present, the plan skill surfaces these at plan-time as advisory context ("this domain typically involves compliance sign-off") but does not enforce or override `approvals.roles`. Absent field and empty list are equivalent — no advisory prompt fires.
 
 **Matching logic (3-tier, in order):**
 1. Explicit `domain:` tag in `scope.md` frontmatter → authoritative
@@ -136,11 +139,19 @@ The load reduction isn't "Claude writes it for you." It's **load shifting from o
 
 **Reshape:** either assign a synthetic REQ-ID (e.g., `REQ-SCOPE-<project>`) or carve out a named exception. Don't silently invent a parallel pattern — that's exactly the drift the accepted RFC prevents.
 
+**Resolution (2026-04-25):** Assign synthetic REQ-ID `REQ-SCOPE-<project-slug>`. Sign-off filename follows the accepted convention: `sign-offs/REQ-SCOPE-<slug>-product.md` (using default role `product`). No named exception needed.
+
 **2. Single-signer assumption.** Proposal wrote "human signs scope" in the singular. With the 9-role set and multi-team approval as accepted policy, certain domains probably need multi-role scope sign-off (payments: product + compliance + security). Current position: default single-role, with domain files declaring when multi-role is required. Needs the 9-role list to resolve.
+
+**Resolution (2026-04-25):** Default signer role is `product`. Drop tentative label `scope-owner` — not in the accepted 9-role vocabulary. Domain files may declare `suggested_roles: [product, compliance, security]` for regulated domains; plan skill surfaces this advisory at plan-time but does not auto-require multi-role sign-off.
 
 **3. Transport ladder.** Proposal assumed chat sign-off as default. Accepted RFC defines Tiers 0–3. Can't say which tier scope sign-off belongs to without reading the ladder. Deferred.
 
+**Resolution (2026-04-25):** Same transport ladder as other sign-offs. Tier 0 (local, authoritative) only for v1. Teams that already use `approvals.share_path` or `approvals.git_repo` for phase sign-offs can use the same keys for scope — no new config.
+
 **4. `APPROVALS.md` reconciler.** Proposal didn't mention it. Scope sign-off output needs to emit something the reconciler can parse. Format constraint unresolved.
+
+**Resolution (2026-04-25):** Scope gate file at `.claude/sdlc/gates/scope-<project>.md` with a `## Required sign-offs` block — same shape as phase gate files per accepted RFC §3.2. Reconciler reads it identically; no new format. Scope acts as a pseudo-phase gate: the sign-off must be present before the first `/plan` builds its plan artifact. Remaining open: whether "pseudo-phase gate" is the right model or whether scope deserves a distinct artifact class. Deferred to scope-ingest RFC promotion.
 
 ### Overlaps with PR #1 (draft)
 
@@ -165,11 +176,11 @@ Untouched by either RFC:
 
 ### What I can't see from outside the repo
 
-Explicit: this analysis is partial without these.
+**All three items resolved 2026-04-25** by reading `multi-team-approval.md` in full and the reshaped `guided-entry-session-resume-multi-role.md`. Resolutions recorded in the four conflict entries above.
 
-1. Full text of `multi-team-approval.md` — needed to resolve sign-off filename, role assignment, transport tier, reconciler format.
-2. The 10-PR contents in PR #1 — unknown overlap surface.
-3. The 9-role set — determines scope sign-off role(s).
+~~1. Full text of `multi-team-approval.md` — needed to resolve sign-off filename, role assignment, transport tier, reconciler format.~~
+~~2. The 10-PR contents in PR #1 — unknown overlap surface.~~
+~~3. The 9-role set — determines scope sign-off role(s).~~
 
 ---
 
@@ -178,7 +189,7 @@ Explicit: this analysis is partial without these.
 - **Domain file curation process.** Who owns `domains/payments.md`? How are updates reviewed? Same discipline as skills, or lighter? Decide later.
 - **Scope regeneration policy.** When the source PDF updates to v4, what happens? Options: ignore / `/plan --refresh-scope` / warn on drift. Ship v1 without regeneration; observe.
 - **Multi-domain matching.** v1 matches top-1 domain; human can override to multi. v2 could auto-match multi. Don't build upfront.
-- **Workflow templates vs. domain files** (from PR #1 pending A). Unify or keep orthogonal. Decide before shipping domain-expert.
+- ~~**Workflow templates vs. domain files**~~ — **Resolved 2026-04-25 (keep orthogonal).** Workflow presets in `/configure` Q5 configure sign-off mechanics (`approvals.roles`, transport); domain files inject domain knowledge (glossary, NFRs, regulatory concerns, gap questions). Advisory bridge: optional `suggested_roles: []` in domain file frontmatter; plan skill surfaces it at plan-time but does not enforce or override `approvals.roles`. Both artifacts evolve independently with separate owners.
 - **Sign-off role naming.** Tentative "scope-owner"; waits on 9-role set confirmation.
 
 ---
@@ -230,6 +241,7 @@ Named so future reviewers can check:
 
 ## Next actions
 
-- Decide on workflow-templates-vs-domain-files unification before building seed domain files (coordinate with PR #1 pending A)
-- Read `multi-team-approval.md` in full; update this note's conflict section
-- Read PR #1's RFC body in full; update overlap section
+- ~~Decide on workflow-templates-vs-domain-files unification before building seed domain files~~ — resolved 2026-04-25; see Open questions above.
+- ~~Read `multi-team-approval.md` in full; update this note's conflict section~~ — done 2026-04-25.
+- ~~Read PR #1's RFC body in full; update overlap section~~ — done 2026-04-25.
+- **Promote this note to a formal RFC** — conflicts resolved, vocabulary aligned, approach stable. Next: draft `docs/rfcs/scope-ingest.md`. Remaining open: pseudo-phase-gate vs. new artifact class (see conflict 4 resolution).

--- a/docs/rfcs/scope-ingest.md
+++ b/docs/rfcs/scope-ingest.md
@@ -29,7 +29,7 @@
 |---|---|
 | 1. Human in the lead | `scope-ingest` drafts; the human validates and signs. The plugin never writes `scope.md` unilaterally. |
 | 2. Plan before code | Unchanged — scope sign-off gates the plan artifact, which already gates all edit operations. |
-| 3. Surgical edits | `scope-ingest` agent has narrow write scope: `scope-drafts/` only. It cannot touch `scope.md` directly. |
+| 3. Surgical edits | `scope-ingest` agent is instructed to write only to `scope-drafts/`. By convention it does not touch `scope.md` directly — enforced through the agent's instructions, not a capability boundary. |
 | 4. Work-item traceability | Scope sign-off uses synthetic REQ-ID `REQ-SCOPE-<project-slug>`, traceable across phases. |
 | 5. Graceful degradation | No source material → fall back to the existing one-paragraph prompt. Works offline. |
 | 6. Stack-agnostic | Domain files and `domains/_index.json` are plain markdown and JSON. No tool-specific logic. |
@@ -91,11 +91,11 @@ A bounded subprocess with narrow write scope (`scope-drafts/` only). Its job is 
 
 **Explicit non-goals:** writing `scope.md` directly, signing anything, deciding domain, fabricating fields where source material is thin.
 
-**Why agent, not skill.** Ingesting a 50-page PDF is expensive and isolated; bounding it to a subprocess keeps main-turn tokens sane. Narrow write scope (`scope-drafts/` only) is a real safety property — the agent cannot widen scope.md silently. The skill pattern is appropriate for `domain-expert` because that is a lightweight read-and-inject operation reused across phases; those economics don't apply here.
+**Why agent, not skill.** Ingesting a 50-page PDF is expensive and isolated; bounding it to a subprocess keeps main-turn tokens sane. Restricting writes to `scope-drafts/` is a convention enforced through the agent's instructions — the agent is given no instruction or need to write `scope.md` directly. This is not a capability boundary: a future change to the agent's instructions would change this behavior. The skill pattern is appropriate for `domain-expert` because that is a lightweight read-and-inject operation; those economics don't apply here.
 
 ### 3.2 `domain-expert` skill
 
-A read-and-inject skill. Invoked by `/plan` now; reusable by `/analyze` and `/design` in later work.
+A read-and-inject skill. Invoked by `/plan` in v1. Cross-phase reuse (`/analyze`, `/design`) is deferred — see §11.
 
 **New directory at plugin root:**
 ```
@@ -130,6 +130,8 @@ suggested_roles: []
 `last_reviewed` and `owner` are load-bearing — without them, domain files rot silently.
 
 `suggested_roles` is optional. When present, the plan skill surfaces these at plan-time as advisory context ("this domain typically involves compliance sign-off") but does not enforce or override `approvals.roles`. Absent field and empty list are equivalent. This is the advisory bridge agreed in the PR #1 Pending A resolution — workflow presets configure the mechanics; domain files advise on domain-specific role patterns.
+
+**Implementation constraint:** `suggested_roles` content must write only into the `## Domain context` section of the plan artifact as a display-only advisory note. It must never populate the gate file's `## Required sign-offs` block. That block is populated from `approvals.roles` in `config/tools.json`, or from explicit human input at plan-gate time. If `approvals.roles` is absent, the gate file's sign-offs block is empty until the human fills it; `suggested_roles` does not substitute.
 
 **Matching logic (3-tier, in order):**
 1. Explicit `domain:` tag in `scope.md` frontmatter → authoritative, no prompt needed
@@ -169,7 +171,7 @@ The user-facing surface is unchanged: same `/plan` command, same gate ritual.
 2. Confirm domain match if confidence is not high
 3. Sign plan gate
 
-The reduction is load *shifting* from open-ended authoring to closed-form answering. First-time setup costs slightly more in exchange for better scope quality from day one. Gap questions are advisory unless the domain file marks a question `required` — teams can tune how much friction the domain expert adds.
+The reduction is load *shifting* from open-ended authoring to closed-form answering. First-time setup costs slightly more in exchange for better scope quality from day one. Gap questions are advisory by default. Questions marked `required: true` produce a warn-level flag — not a hard block — so teams can tune signal level without hard-stopping legitimate work.
 
 ## 4. Domain file schema
 
@@ -183,7 +185,7 @@ Optional sections: `## Glossary`, `## Typical NFRs`, `## Regulatory concerns`, `
 
 Sections with no content for a given domain are omitted entirely rather than present-but-empty — empty sections are noise that lowers the signal-to-noise ratio when the plan skill injects domain context.
 
-**Questions can be marked `required`.** A question marked `required: true` (inline tag) blocks plan sign-off if the plan artifact doesn't address it. Questions without the tag are advisory — surfaced in the `## Domain context` section but not enforced. Default: advisory. Only mark required when the gap genuinely voids the plan.
+**Questions can be marked `required`.** A question marked `required: true` (inline tag) produces a warn-level flag in the plan artifact's `## Domain context` section when the plan doesn't address it. Questions without the tag are advisory — surfaced but not flagged. Default: advisory. Per the repo's hook philosophy (`CLAUDE.md`), `exit 2` hard blocks are reserved for severe consequences (no plan at all, unsigned CR, confirmed secret); an unanswered domain question is a gap worth surfacing, not a confirmed catastrophe. The human can proceed after acknowledging the flag. Only mark `required: true` when the gap genuinely voids the plan's correctness, knowing the check is warn-only.
 
 **v1 seed files: `payments.md` and `auth.md`.** Two domains are enough to test the machinery. Start narrow — a seed that says too much becomes noise; a seed that says nothing is useless. Expand based on observed gaps after dry-runs on real past plan artifacts.
 
@@ -196,7 +198,7 @@ All four conflicts identified in the discussion note are resolved. No named exce
 | Sign-off filename convention | Synthetic REQ-ID `REQ-SCOPE-<project-slug>`. File: `sign-offs/REQ-SCOPE-<slug>-product.md`. Follows accepted RFC's `<REQ-ID>-<role>.md` pattern. |
 | Signer role | Default role is `product`. Drop tentative label `scope-owner` — not in the 9-role vocabulary. Domain files may declare `suggested_roles` for regulated domains; advisory, not enforced. |
 | Transport ladder | Same Tier 0–3 ladder as phase sign-offs. Tier 0 (local, authoritative) only for v1. Teams already using `approvals.share_path` or `approvals.git_repo` for phase sign-offs use the same keys; no new config. |
-| Reconciler / `APPROVALS.md` | Scope gate file at `.claude/sdlc/gates/scope-<project>.md` with `## Required sign-offs` block — same shape as phase gate files per §3.2 of the accepted RFC. Reconciler reads it identically; no new format. |
+| Reconciler / `APPROVALS.md` | Scope gate file at `.claude/sdlc/gates/scope-<project>.md` with `## Required sign-offs` block and a `gate_hash` field (sha256 of gate content above `## Required sign-offs`, per accepted RFC §6.5) — same shape as phase gate files per accepted RFC §3.2. Reconciler reads it identically; no new format. |
 
 ## 6. Open question — OQ-SCOPE-1
 
@@ -213,11 +215,13 @@ Scope currently acts as a **pseudo-phase gate** (same gate file shape as `plan-<
 
 **Proposal:** ship v1 as a pseudo-phase gate (low cost, unblocks the rest of the feature). If real usage shows the gate label confusion causes operator errors, promote to a new artifact class in a follow-on amendment. The gate file content and sign-off file format are identical either way — the upgrade is a rename and a registry entry, not a data migration.
 
-**Answer:** *(pending — resolve before implementation begins)*
+**Approval condition:** This RFC must not be signed off until OQ-SCOPE-1 is answered. All gate-related implementation items — `templates/scope-gate.md`, the `plan-gate.sh` modification, and the reconciler's `APPROVALS.md` projection behavior — depend on this answer. Record the decision as an inline amendment here before implementation begins.
+
+**Answer:** *(pending)*
 
 ## 7. Architectural decisions
 
-- **Agent for `scope-ingest`, skill for `domain-expert`.** Agent when bounded write scope and expensive isolated work justify the subprocess cost. Skill when it is a reusable read-and-inject pattern across phases. This distinction is not cosmetic — agents cost more tokens per invocation.
+- **Agent for `scope-ingest`, skill for `domain-expert`.** Agent when expensive isolated work justifies the subprocess cost and restricting write scope via instructions is the right architectural choice. Skill when it is a lightweight read-and-inject operation. Agents cost more tokens per invocation; this is a resource tradeoff, not a cosmetic distinction.
 - **No new commands.** Cognitive load lives at the command level. `/plan` stays the single entry point. Both capabilities hang off it internally.
 - **`scope.md` is a derived, validated artifact — not an authoring target.** This lets the plugin accept any source format: the human points at material, the agent derives, the human validates and signs.
 - **Gap report, not draft.** A draft invites rubber-stamping. A gap report forces targeted answers. The load reduction happens here, not in automation.
@@ -227,7 +231,7 @@ Scope currently acts as a **pseudo-phase gate** (same gate file shape as `plan-<
 
 - **Domain files too generic.** "Payments" covers too much → gap questions become noise → humans ignore. Start narrow; expand based on observed gaps from dry-runs.
 - **Over-aggressive ingestion.** Fabricating scope from thin sources → subtly wrong signed scope → every downstream phase drifts. Mitigation: per-bullet provenance, source-next-to-extracted-bullet view before signing.
-- **Onerous first-time setup.** If scope ingest + domain validation makes greenfield setup painful, teams skip the plugin. Mitigation: minimum-viable one-paragraph scope remains acceptable; gap questions are advisory unless domain file marks them `required`.
+- **Onerous first-time setup.** If scope ingest + domain validation makes greenfield setup painful, teams skip the plugin. Mitigation: minimum-viable one-paragraph scope remains acceptable; all gap questions are warn-only (even those marked `required: true`), so the domain expert adds signal without blocking work.
 - **Stale domain files.** `last_reviewed` + `owner` required; treat as living documentation. A domain file without an owner silently becomes the worst kind of documentation.
 - **Wrong domain match.** Wrong checklist → wrong gaps → misleading scope. Low-confidence matches require human confirmation; no silent assignment.
 
@@ -249,7 +253,7 @@ No improvement percentages committed here. Baseline first, interpret later.
 |---|---|
 | Human in the lead | `scope-ingest` drafts; human signs. `domain-expert` reports gaps; human confirms. No auto-advancement. |
 | Plan before code | `plan-gate.sh` is unchanged. Scope sign-off gates the plan artifact; plan artifact gates edit operations. |
-| Surgical edits | `scope-ingest` agent write scope is `scope-drafts/` only. `domain-expert` reads and injects; writes nothing. |
+| Surgical edits | `scope-ingest` agent is instructed to write only to `scope-drafts/` (convention, not a capability boundary). `domain-expert` reads and injects; writes nothing. |
 | Work-item traceability | `REQ-SCOPE-<slug>` is a stable, traceable identifier across phases. |
 | Graceful degradation | No source → one-paragraph fallback. Missing domain match → proceed without injection. Missing transport → Tier 0 local. |
 | Stack-agnostic | Domain files are plain markdown + JSON. No tool-specific logic anywhere. |
@@ -262,6 +266,7 @@ No improvement percentages committed here. Baseline first, interpret later.
 - Scope regeneration policy when source document updates (observe v1 behavior first)
 - Domain file curation process and review cadence (decide after seeing how stale files manifest in practice)
 - Appeal paths, rollback, or retrospective scope audits
+- Wiring `domain-expert` into `/analyze` and `/design` (v1 only: invoked from `/plan`; cross-phase reuse deferred until v1 usage validates the skill's gap question quality)
 
 ## 12. Alternatives considered
 
@@ -279,6 +284,7 @@ No improvement percentages committed here. Baseline first, interpret later.
 - Existing `/plan` invocations without domain files proceed with `domain: unknown` — no injection, no disruption.
 - `domains/` directory is additive; absent directory means no domain detection (same as `domain: unknown`).
 - Scope gate file is a new artifact — existing repos have no `gates/scope-<project>.md`. First `/plan` after install creates it. No migration.
+- Repos with an existing unsigned `scope.md` and established phase sign-offs using role names that differ from what `suggested_roles` in a newly-added domain file would recommend will see reconciler warn-level output noting the mismatch. This is the expected behavior — the reconciler surfaces the signal; the human decides whether to update the gate file's `## Required sign-offs` block or proceed as-is.
 
 ## 14. Implementation checklist
 
@@ -294,10 +300,10 @@ Sequencing follows the principle: validate the schema before building consumers;
 - [ ] Build `scope-ingest` agent — markdown + plain text parsers first; PDF in a follow-up; DOCX/PPTX/URL as a separate scoped change
 - [ ] Add `scope-drafts/` to the artifact tree in `.claude/sdlc/`
 - [ ] Modify `skills/plan/SKILL.md` — wire in Step 2 (scope-ingest invocation) and Step 3 (domain-expert injection)
-- [ ] Write scope gate file template (`templates/scope-gate.md`) with `## Required sign-offs` block
+- [ ] Write scope gate file template (`templates/scope-gate.md`) with `## Required sign-offs` block and `gate_hash` field (sha256 of content above `## Required sign-offs`, per accepted RFC §6.5)
 - [ ] Add scope gate check to `hooks/plan-gate.sh`
 - [ ] Dry-run end-to-end on one real project: source → draft → sign → plan → domain inject → gate
-- [ ] Documentation pass: README "Scope setup" section; `docs/SDLC.md` Phase 1 update; `docs/GLOSSARY.md` entries for new terms (scope draft, provenance footer, domain context, gap questions)
+- [ ] Documentation pass: README "Scope setup" section; `docs/SDLC.md` Phase 1 update; `docs/GLOSSARY.md` entries for new terms (scope draft, provenance footer, domain context, gap questions, and the OQ-SCOPE-1 resolved term for the scope gate — "pseudo-phase gate" or "scope gate artifact" per whichever answer is chosen)
 
 ---
 

--- a/docs/rfcs/scope-ingest.md
+++ b/docs/rfcs/scope-ingest.md
@@ -1,0 +1,304 @@
+# RFC: Scope Ingest and Domain-Expert Skill
+
+**Status:** Draft
+
+**Author:** Charlton Ho
+**Target:** `lantisprime/claude-sdlc`
+**Date:** 2026-04-25
+**Promoted from:** `docs/rfcs/notes/plan-phase-scope-ingest-discussion.md` (discussion note preserved as historical record)
+
+**Related:**
+- `docs/rfcs/multi-team-approval.md` (accepted 2026-04-19) — sign-off conventions; all conflicts resolved, see §5
+- `docs/rfcs/guided-entry-session-resume-multi-role.md` (PR #1, draft) — Pending A resolved 2026-04-25; workflow presets and domain files are orthogonal, see §3.2
+
+---
+
+## 1. Problem
+
+`scope.md` today is authored by the human at first `/plan` invocation. Three failure modes:
+
+1. **Format sprawl.** Real-world scope lives in PDFs, Word docs, PPTX briefs, Confluence pages, Notion, Jira epics. The human has to translate any of those into a one-paragraph chat statement or a hand-written markdown file.
+2. **Quality uncertainty.** There is no validation that `scope.md` is clear, complete, or aligned with domain-specific regulations. The plan skill reads it and trusts it.
+3. **Cognitive load.** Open-ended authoring ("write the scope statement") is higher load than closed-form answering ("answer these four questions"). The plugin's own design philosophy — reduce surprise, reduce friction at the expensive moments — applies to scope too.
+
+`scope.md` is the artifact every downstream phase validates against. Getting it wrong silently widens what the plugin permits for the lifetime of the project.
+
+## 2. Design goals (mapped to core principles)
+
+| Principle | How this RFC respects it |
+|---|---|
+| 1. Human in the lead | `scope-ingest` drafts; the human validates and signs. The plugin never writes `scope.md` unilaterally. |
+| 2. Plan before code | Unchanged — scope sign-off gates the plan artifact, which already gates all edit operations. |
+| 3. Surgical edits | `scope-ingest` agent has narrow write scope: `scope-drafts/` only. It cannot touch `scope.md` directly. |
+| 4. Work-item traceability | Scope sign-off uses synthetic REQ-ID `REQ-SCOPE-<project-slug>`, traceable across phases. |
+| 5. Graceful degradation | No source material → fall back to the existing one-paragraph prompt. Works offline. |
+| 6. Stack-agnostic | Domain files and `domains/_index.json` are plain markdown and JSON. No tool-specific logic. |
+
+## 3. Proposed design
+
+### 3.0 Component overview
+
+```mermaid
+flowchart TB
+    Human([Human])
+
+    subgraph Plan["/plan invocation"]
+        Classify["1. Classify work item"]
+        ResolveScope["2. Resolve scope\n(scope-ingest agent or fallback)"]
+        DetectDomain["3. Detect + load domain\n(domain-expert skill)"]
+        WritePlan["4. Write plan artifact\n(includes ## Domain context)"]
+        Gate["6. Human gate sign-off"]
+    end
+
+    subgraph Artifacts["Artifacts"]
+        ScopeDraft[".claude/sdlc/scope-drafts/<timestamp>.md"]
+        ScopeMd[".claude/sdlc/scope.md (signed)"]
+        DomainFiles["domains/<slug>.md"]
+        PlanFile[".claude/sdlc/plans/<slug>.md"]
+        ScopeGate[".claude/sdlc/gates/scope-<project>.md"]
+        SignOff[".claude/sdlc/sign-offs/REQ-SCOPE-<slug>-product.md"]
+    end
+
+    Human -->|points at source| ResolveScope
+    ResolveScope --> ScopeDraft
+    ScopeDraft -->|human reviews + edits| ScopeMd
+    ScopeMd --> ScopeGate
+    Human -->|signs| SignOff
+    SignOff --> ScopeGate
+    DomainFiles --> DetectDomain
+    ScopeMd --> DetectDomain
+    DetectDomain --> WritePlan
+    WritePlan --> PlanFile
+    PlanFile --> Gate
+```
+
+### 3.1 `scope-ingest` agent
+
+A bounded subprocess with narrow write scope (`scope-drafts/` only). Its job is turning raw source material into a normalized, provenance-traced scope draft. The human reviews the draft, makes any corrections, and signs it.
+
+**Accepted source formats:**
+- File paths: `.md`, `.txt`, `.pdf`, `.docx`, `.pptx`
+- URLs (auth-walled sources require the human to export and paste content first)
+- Ticket references (if Jira/Linear MCP is wired via `env.json`)
+- Raw chat text
+- An existing `scope.md` (re-validate mode — reports drift; does not rewrite)
+
+**Pipeline:**
+1. Parse to plain-text blocks with provenance (source file, page/section, line span)
+2. Normalize into a fixed schema: `project_name`, `domain`, `in_scope[]`, `out_of_scope[]`, `success_criteria`, `constraints[]`, `stakeholders`, `assumptions`. Absent fields stay absent — no fabrication.
+3. Emit a draft at `.claude/sdlc/scope-drafts/<timestamp>.md` with a per-bullet provenance footer so every extracted claim traces to its source span.
+4. Return to the plan skill: draft path + extraction confidence per field.
+
+**Explicit non-goals:** writing `scope.md` directly, signing anything, deciding domain, fabricating fields where source material is thin.
+
+**Why agent, not skill.** Ingesting a 50-page PDF is expensive and isolated; bounding it to a subprocess keeps main-turn tokens sane. Narrow write scope (`scope-drafts/` only) is a real safety property — the agent cannot widen scope.md silently. The skill pattern is appropriate for `domain-expert` because that is a lightweight read-and-inject operation reused across phases; those economics don't apply here.
+
+### 3.2 `domain-expert` skill
+
+A read-and-inject skill. Invoked by `/plan` now; reusable by `/analyze` and `/design` in later work.
+
+**New directory at plugin root:**
+```
+domains/
+├── _index.json          # keyword + stack → domain slug
+├── _schema.md           # required shape for domain files
+├── payments.md          # seed
+├── auth.md              # seed
+└── ...
+```
+
+**Domain file shape:**
+```
+---
+slug: payments
+last_reviewed: 2026-03-15
+owner: <team-or-person>
+suggested_roles: []
+---
+# Payments
+
+## Glossary
+## Typical NFRs
+## Regulatory concerns
+## Common pitfalls
+## Stack notes
+## Security hotspots
+## Scope must address
+## Questions plan must answer
+```
+
+`last_reviewed` and `owner` are load-bearing — without them, domain files rot silently.
+
+`suggested_roles` is optional. When present, the plan skill surfaces these at plan-time as advisory context ("this domain typically involves compliance sign-off") but does not enforce or override `approvals.roles`. Absent field and empty list are equivalent. This is the advisory bridge agreed in the PR #1 Pending A resolution — workflow presets configure the mechanics; domain files advise on domain-specific role patterns.
+
+**Matching logic (3-tier, in order):**
+1. Explicit `domain:` tag in `scope.md` frontmatter → authoritative, no prompt needed
+2. Rule match against `domains/_index.json` → confidence `high` / `medium` / `low`
+3. No match → `domain: unknown`, proceed without injection
+
+Low-confidence matches require human confirmation at the plan gate before the domain context is written to the plan artifact. No silent assignment.
+
+**Output:** a `## Domain context` section in the plan artifact containing matched domain, confidence level, unanswered items from `Questions plan must answer`, and `Scope must address` items the current scope doesn't cover.
+
+### 3.3 Modified `/plan` flow
+
+Six steps instead of five:
+
+| Step | What happens | Changed? |
+|---|---|---|
+| 1 | Classify work item | Unchanged |
+| 2 | **Resolve scope** — if `scope.md` exists and is signed, read it. Otherwise invoke `scope-ingest` against the source the human points at. No source → prompt for one-paragraph statement (existing fallback). | **New** |
+| 3 | **Detect and load domain** — `domain-expert` matches scope + stack, produces gap questions | **New** |
+| 4 | Write plan artifact, including `## Domain context` section | Modified (new section) |
+| 5 | Record tech stack + compatibility matrix | Unchanged |
+| 6 | Human gate — sign-off covers plan + domain confirmation | Unchanged |
+
+The user-facing surface is unchanged: same `/plan` command, same gate ritual.
+
+### 3.4 Cognitive load — honest accounting
+
+**First `/plan` in a new repo (increases slightly):**
+1. Point at source material (path, URL, or paste text)
+2. Answer gap questions (closed-form, not open-ended)
+3. Sign scope — new one-time step
+4. Confirm domain match if confidence is not high
+5. Sign plan gate — existing
+
+**Subsequent `/plan` runs (roughly unchanged):**
+1. Run `/plan "<task>"`
+2. Confirm domain match if confidence is not high
+3. Sign plan gate
+
+The reduction is load *shifting* from open-ended authoring to closed-form answering. First-time setup costs slightly more in exchange for better scope quality from day one. Gap questions are advisory unless the domain file marks a question `required` — teams can tune how much friction the domain expert adds.
+
+## 4. Domain file schema
+
+The `domains/_schema.md` file defines the contract all domain files must follow. Implementers write it before writing the first seed file so the seed validates the schema rather than defines it.
+
+Required frontmatter: `slug`, `last_reviewed`, `owner`.
+Optional frontmatter: `suggested_roles`.
+
+Required sections: `## Scope must address`, `## Questions plan must answer`.
+Optional sections: `## Glossary`, `## Typical NFRs`, `## Regulatory concerns`, `## Common pitfalls`, `## Stack notes`, `## Security hotspots`.
+
+Sections with no content for a given domain are omitted entirely rather than present-but-empty — empty sections are noise that lowers the signal-to-noise ratio when the plan skill injects domain context.
+
+**Questions can be marked `required`.** A question marked `required: true` (inline tag) blocks plan sign-off if the plan artifact doesn't address it. Questions without the tag are advisory — surfaced in the `## Domain context` section but not enforced. Default: advisory. Only mark required when the gap genuinely voids the plan.
+
+**v1 seed files: `payments.md` and `auth.md`.** Two domains are enough to test the machinery. Start narrow — a seed that says too much becomes noise; a seed that says nothing is useless. Expand based on observed gaps after dry-runs on real past plan artifacts.
+
+## 5. Sign-off alignment with accepted `multi-team-approval.md`
+
+All four conflicts identified in the discussion note are resolved. No named exceptions to the accepted RFC's conventions are needed.
+
+| Conflict | Resolution |
+|---|---|
+| Sign-off filename convention | Synthetic REQ-ID `REQ-SCOPE-<project-slug>`. File: `sign-offs/REQ-SCOPE-<slug>-product.md`. Follows accepted RFC's `<REQ-ID>-<role>.md` pattern. |
+| Signer role | Default role is `product`. Drop tentative label `scope-owner` — not in the 9-role vocabulary. Domain files may declare `suggested_roles` for regulated domains; advisory, not enforced. |
+| Transport ladder | Same Tier 0–3 ladder as phase sign-offs. Tier 0 (local, authoritative) only for v1. Teams already using `approvals.share_path` or `approvals.git_repo` for phase sign-offs use the same keys; no new config. |
+| Reconciler / `APPROVALS.md` | Scope gate file at `.claude/sdlc/gates/scope-<project>.md` with `## Required sign-offs` block — same shape as phase gate files per §3.2 of the accepted RFC. Reconciler reads it identically; no new format. |
+
+## 6. Open question — OQ-SCOPE-1
+
+### Pseudo-phase gate vs. new artifact class
+
+Scope currently acts as a **pseudo-phase gate** (same gate file shape as `plan-<slug>.md`, `analyze-<slug>.md`, etc., just at a pre-Plan position). The alternative is treating scope as a **first-class artifact class** with its own schema, its own sign-off template variant, and explicit registry in `env.json`.
+
+| | Pseudo-phase gate | New artifact class |
+|---|---|---|
+| Implementation cost | Low — reconciler already handles phase gates; no new code path | Higher — new artifact schema, new registry entry, new skill branch |
+| Conceptual clarity | Lower — scope isn't really a phase; the "pre-Plan gate" label confuses the 8-phase model | Higher — scope is genuinely different from a phase gate |
+| Downstream ripple | Minimal — downstream phases read `scope.md`, not the gate file | Contained — the artifact class is new; existing phases are unaffected |
+| `APPROVALS.md` projection | Works today with no changes | Requires reconciler to understand the new class |
+
+**Proposal:** ship v1 as a pseudo-phase gate (low cost, unblocks the rest of the feature). If real usage shows the gate label confusion causes operator errors, promote to a new artifact class in a follow-on amendment. The gate file content and sign-off file format are identical either way — the upgrade is a rename and a registry entry, not a data migration.
+
+**Answer:** *(pending — resolve before implementation begins)*
+
+## 7. Architectural decisions
+
+- **Agent for `scope-ingest`, skill for `domain-expert`.** Agent when bounded write scope and expensive isolated work justify the subprocess cost. Skill when it is a reusable read-and-inject pattern across phases. This distinction is not cosmetic — agents cost more tokens per invocation.
+- **No new commands.** Cognitive load lives at the command level. `/plan` stays the single entry point. Both capabilities hang off it internally.
+- **`scope.md` is a derived, validated artifact — not an authoring target.** This lets the plugin accept any source format: the human points at material, the agent derives, the human validates and signs.
+- **Gap report, not draft.** A draft invites rubber-stamping. A gap report forces targeted answers. The load reduction happens here, not in automation.
+- **Provenance footer required.** Every scope bullet traces to its source span. Without this, fabrication in the normalization step is undetectable at sign-off.
+
+## 8. Failure modes to guard against
+
+- **Domain files too generic.** "Payments" covers too much → gap questions become noise → humans ignore. Start narrow; expand based on observed gaps from dry-runs.
+- **Over-aggressive ingestion.** Fabricating scope from thin sources → subtly wrong signed scope → every downstream phase drifts. Mitigation: per-bullet provenance, source-next-to-extracted-bullet view before signing.
+- **Onerous first-time setup.** If scope ingest + domain validation makes greenfield setup painful, teams skip the plugin. Mitigation: minimum-viable one-paragraph scope remains acceptable; gap questions are advisory unless domain file marks them `required`.
+- **Stale domain files.** `last_reviewed` + `owner` required; treat as living documentation. A domain file without an owner silently becomes the worst kind of documentation.
+- **Wrong domain match.** Wrong checklist → wrong gaps → misleading scope. Low-confidence matches require human confirmation; no silent assignment.
+
+## 9. What we will measure
+
+Following the existing `token-tracker.sh` pattern — JSONL lines appended to a history file.
+
+- Source type distribution (file path / URL / ticket ref / raw text / fallback one-paragraph)
+- Extraction confidence per field, per run — tracks whether domain file quality improves over time
+- Number of gap questions answered vs. deferred per plan
+- Scope drift detected by re-validate mode (how often does the source update between plans?)
+- Domain match confidence distribution — how often do users override low-confidence matches?
+
+No improvement percentages committed here. Baseline first, interpret later.
+
+## 10. Alignment with design principles
+
+| Principle | How this RFC preserves it |
+|---|---|
+| Human in the lead | `scope-ingest` drafts; human signs. `domain-expert` reports gaps; human confirms. No auto-advancement. |
+| Plan before code | `plan-gate.sh` is unchanged. Scope sign-off gates the plan artifact; plan artifact gates edit operations. |
+| Surgical edits | `scope-ingest` agent write scope is `scope-drafts/` only. `domain-expert` reads and injects; writes nothing. |
+| Work-item traceability | `REQ-SCOPE-<slug>` is a stable, traceable identifier across phases. |
+| Graceful degradation | No source → one-paragraph fallback. Missing domain match → proceed without injection. Missing transport → Tier 0 local. |
+| Stack-agnostic | Domain files are plain markdown + JSON. No tool-specific logic anywhere. |
+
+## 11. Non-goals
+
+- Adding a `/scope` command or any other user-visible command
+- Auto-writing `scope.md` without human review and sign-off
+- Multi-domain matching in v1 (top-1 match; human can override)
+- Scope regeneration policy when source document updates (observe v1 behavior first)
+- Domain file curation process and review cadence (decide after seeing how stale files manifest in practice)
+- Appeal paths, rollback, or retrospective scope audits
+
+## 12. Alternatives considered
+
+**A separate `/scope` command.** Rejected — adds a command users must memorize. The plugin's anti-patterns section explicitly flags this. Both capabilities hang off `/plan` internally.
+
+**LLM-generated scope without provenance.** Rejected — fabrication at scope produces the worst possible downstream drift because `scope.md` gates every subsequent phase. Provenance-traced gap report is the only honest alternative.
+
+**Domain files as part of the workflow preset (Pending A, unified option).** Rejected 2026-04-25 — workflow presets configure sign-off mechanics; domain files encode domain knowledge. Different purposes, different owners, different evolution cadence. Advisory `suggested_roles` bridge is the narrowest connection that recovers the useful part of unification without merging stewardship.
+
+**Domain file matching via full-text semantic search.** Over-engineered for v1 — keyword + stack rules in `_index.json` are transparent, debuggable, and correctable. Semantic search adds a model dependency for a matching problem that is mostly "does the scope mention payments / auth / healthcare?" Upgrade path is clear if keyword rules prove insufficient.
+
+## 13. Backward compatibility
+
+- Existing repos with a hand-written `scope.md` are not affected — Step 2 reads the existing file and proceeds. `scope-ingest` is only invoked when `scope.md` is absent or unsigned.
+- Existing `/plan` invocations without domain files proceed with `domain: unknown` — no injection, no disruption.
+- `domains/` directory is additive; absent directory means no domain detection (same as `domain: unknown`).
+- Scope gate file is a new artifact — existing repos have no `gates/scope-<project>.md`. First `/plan` after install creates it. No migration.
+
+## 14. Implementation checklist
+
+Sequencing follows the principle: validate the schema before building consumers; build the skill before the agent; wire them into `/plan` last.
+
+- [ ] Resolve OQ-SCOPE-1 (pseudo-phase gate vs. artifact class) before writing any gate-related code
+- [ ] Write `domains/_schema.md` — the contract all domain files must follow
+- [ ] Write `domains/payments.md` seed file
+- [ ] Write `domains/auth.md` seed file
+- [ ] Write `domains/_index.json` with keyword + stack rules for payments and auth
+- [ ] Build `domain-expert` skill — reads `_index.json`, matches, injects `## Domain context` into plan artifact
+- [ ] Dry-run `domain-expert` against 3–5 past plan artifacts to validate gap question quality
+- [ ] Build `scope-ingest` agent — markdown + plain text parsers first; PDF in a follow-up; DOCX/PPTX/URL as a separate scoped change
+- [ ] Add `scope-drafts/` to the artifact tree in `.claude/sdlc/`
+- [ ] Modify `skills/plan/SKILL.md` — wire in Step 2 (scope-ingest invocation) and Step 3 (domain-expert injection)
+- [ ] Write scope gate file template (`templates/scope-gate.md`) with `## Required sign-offs` block
+- [ ] Add scope gate check to `hooks/plan-gate.sh`
+- [ ] Dry-run end-to-end on one real project: source → draft → sign → plan → domain inject → gate
+- [ ] Documentation pass: README "Scope setup" section; `docs/SDLC.md` Phase 1 update; `docs/GLOSSARY.md` entries for new terms (scope draft, provenance footer, domain context, gap questions)
+
+---
+
+*End of RFC.*

--- a/docs/rfcs/scope-ingest.md
+++ b/docs/rfcs/scope-ingest.md
@@ -217,7 +217,11 @@ Scope currently acts as a **pseudo-phase gate** (same gate file shape as `plan-<
 
 **Approval condition:** This RFC must not be signed off until OQ-SCOPE-1 is answered. All gate-related implementation items — `templates/scope-gate.md`, the `plan-gate.sh` modification, and the reconciler's `APPROVALS.md` projection behavior — depend on this answer. Record the decision as an inline amendment here before implementation begins.
 
-**Answer:** *(pending)*
+**Answer (resolved 2026-04-25): pseudo-phase gate for v1.**
+
+Rationale: the artifact format is identical to phase gate files; the reconciler handles it today with no code changes; the upgrade path to a new artifact class is a rename + `env.json` registry entry with no data migration. The label imprecision ("scope isn't a phase") is real but addressable via the glossary rather than requiring a new code path at this stage.
+
+**New artifact class deferred to v2.** After v1 ships and real usage is observed, evaluate whether the "pre-Plan gate" label causes operator confusion or whether reconciler behavior for scope needs to diverge from phase gate behavior. If either condition holds, promote to a new artifact class in a follow-on RFC amendment. The v2 checklist item is: (a) add `scope_gate` entry to `env.json` artifact registry, (b) rename `gates/scope-<project>.md` convention if needed, (c) add a reconciler branch for the new class. No data migration required — the file content is the same either way.
 
 ## 7. Architectural decisions
 
@@ -290,7 +294,7 @@ No improvement percentages committed here. Baseline first, interpret later.
 
 Sequencing follows the principle: validate the schema before building consumers; build the skill before the agent; wire them into `/plan` last.
 
-- [ ] Resolve OQ-SCOPE-1 (pseudo-phase gate vs. artifact class) before writing any gate-related code
+- [x] ~~Resolve OQ-SCOPE-1~~ — resolved 2026-04-25: pseudo-phase gate for v1 (see §6)
 - [ ] Write `domains/_schema.md` — the contract all domain files must follow
 - [ ] Write `domains/payments.md` seed file
 - [ ] Write `domains/auth.md` seed file


### PR DESCRIPTION
## Status

**Draft — reshaped 2026-04-24 against accepted `multi-team-approval.md`; ready for review.**

## What changed in the reshape

This RFC was previously flagged DRAFT / DO NOT MERGE because two of its ten PRs conflicted with the already-accepted [`multi-team-approval.md`](../blob/main/docs/rfcs/multi-team-approval.md). Reshape collapses it to eight PRs that layer UX on top of that accepted mechanism without duplicating it.

**Dropped:** former PR 5 (in-session `approvals.chain` + assignments config) and PR 7 (commits-as-signatures, `@@SIGNATURE` blocks, `CLAUDE_SDLC_APPROVER_IDENTITY` env var). Both mechanisms are handled differently by the accepted RFC (one-file-per-signer + file transports).

**Kept + adjusted to accepted vocabulary:** PRs 1, 2, 3, 4, 6, 8, 9, 10.

**Compensating additions (option-b) to recover the multi-role UX lost by dropping PR 5:**

- **PR 1** — `/status` gains an unordered pipe-separated sign-off render for the active gate: `security ✓ | product ✓ | compliance □`. Honest about the accepted RFC's parallel (not sequential) model.
- **PR 3** — SessionStart hook gains opt-out historical-email personalization. Matches `git config user.email` against `signer:` fields on past sign-offs to upgrade "sign-offs pending: security, compliance" → "likely awaiting your signature (security) — based on past sign-offs." No new config; no role-to-email map.
- **PR 9** — glossary and `/help sign-offs` gain an explicit unordered-parallel callout so users don't assume a chain that isn't there.

## Summary

Eight PRs, ship order `1 → 2 → 3 → 4 → 8 → 9 → 6 → 10`:

| PR | Concern |
|---|---|
| 1 | `/status` — read-only task state + sign-off progress render |
| 2 | `/start` — guided intake, front door for new users |
| 3 | SessionStart plan-check hook with opt-out personalization |
| 4 | Plan versioning and supersede |
| 8 | `/configure` — Layer 0–3 invocation, 8-question budget |
| 9 | Glossary + `/help` + shared message library |
| 6 | Approval packet — feeds accepted RFC's `evidence:` field |
| 10 | Automatic next-step hints — output convention across skills |

## Design intent preserved

| Principle | Check |
|---|---|
| Human in the lead | All sign-offs still authored by a human; PR 3's personalization is advisory + opt-out |
| Plan before code | PR 4 strengthens plan-gate; accepted RFC's `gate_hash` aligns |
| Surgical edits | Each PR is one concern |
| Work-item traceability | PR 6 strengthens via `evidence:` target |
| Graceful degradation | Every new key is optional |
| Stack-agnostic | No hardcoded tool names |

## Open pending discussions

Deferred, each can fold into an existing PR or ship later:

- **A.** Workflow templates in `/configure` (coordinate with `docs/rfcs/notes/plan-phase-scope-ingest-discussion.md`)
- **B.** Back/cancel navigation in interactive flows
- **C.** Error-message audit to a three-part template
- **D.** TodoWrite integration for long-running phases
- **E.** Per-phase checklist rendering in `/status`

## Test plan

- [ ] Second-opinion review of this reshape
- [ ] Resolve pending discussion A (coordinate with scope-ingest note)
- [ ] Each PR ships independently per the ship order; dogfood on 2–3 real projects
- [ ] Collect blockers from real usage before adding anything to the deferred list

## Files changed in this reshape commit

- `docs/rfcs/guided-entry-session-resume-multi-role.md` — main RFC, reshaped end-to-end
- `docs/rfcs/notes/guided-entry-pr7-degradation.md` — marked `superseded`, kept for history
- `docs/rfcs/notes/README.md` — current-contents table updated
- `docs/rfcs/notes/_repo-context.md` — PR #1 entry updated to reshape-ready state

## Out of scope for this PR

- Implementation of any of the 8 PRs (each ships as its own PR against `main`)
- Modifications to `multi-team-approval.md` — that RFC is authoritative
- Resolution of pending discussions A–E

🤖 Generated with [Claude Code](https://claude.com/claude-code)