### PR TITLE
chore: annotate devFiles and add scripts/ to exclusion list

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -8,5 +8,6 @@
   },
   "license": "MIT",
   "keywords": ["sdlc", "workflow", "governance", "agentic", "human-in-the-loop"],
-  "devFiles": ["AGENT-RULES.md", "CLAUDE.md", "docs/", "tests/", "CHANGELOG.md"]
+  "_devFiles_comment": "Consumed by scripts/package.sh — excluded from consumer distribution. Not recognized by the Claude Code installer.",
+  "devFiles": ["AGENT-RULES.md", "CLAUDE.md", "docs/", "tests/", "CHANGELOG.md", "scripts/"]
 }


### PR DESCRIPTION
## Summary
- Adds `_devFiles_comment` to `plugin.json` to clarify that `devFiles` is consumed by `scripts/package.sh`, not the Claude Code installer
- Adds `scripts/` to the `devFiles` exclusion list so the packaging script is not shipped to consumers

## RFC
RFC-002 PR-1 — see [`docs/rfcs/RFC-002-release-packaging.md`](docs/rfcs/RFC-002-release-packaging.md)

## Merge order
This PR has no dependencies. **Must merge before PR-3** — `scripts/` must be in `devFiles` before `package.sh` runs, otherwise the script includes itself in the distribution archive.

## Test plan
- [ ] `cat .claude-plugin/plugin.json` — confirm `_devFiles_comment` present and `scripts/` in `devFiles` array
- [ ] `python3 -c "import json; json.load(open('.claude-plugin/plugin.json'))"` — confirm valid JSON

🤖 Generated with [Claude Code](https://claude.ai/claude-code)