### PR TITLE
feat: add marketplace catalog for self-hosted plugin distribution

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "claude-sdlc",
+  "metadata": {
+    "owner": { "name": "lantisprime", "url": "https://github.com/lantisprime/claude-sdlc" }
+  },
+  "plugins": [
+    {
+      "name": "sdlc-plugin",
+      "description": "Enforces an 8-phase SDLC workflow for Claude Code with human sign-off at every gate.",
+      "source": {
+        "source": "github",
+        "repo": "lantisprime/claude-sdlc",
+        "ref": "v1.1.0"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `.claude-plugin/marketplace.json` so consumers can install via the Claude Code plugin marketplace system
- `ref` is set to `v1.1.0` (current version) and will be updated automatically by the release workflow (PR-4) on each release

## Consumer install flow (after this PR + PR-4 merge)
\`\`\`bash
/plugin marketplace add lantisprime/claude-sdlc
/plugin install sdlc-plugin@claude-sdlc
\`\`\`

## RFC
RFC-002 PR-2 — see [`docs/rfcs/RFC-002-release-packaging.md`](docs/rfcs/RFC-002-release-packaging.md)

## Merge order
No hard dependencies. Can merge anytime. PR-4 (release workflow) must merge before the `ref` field starts being auto-updated.

## Test plan
- [ ] `python3 -c "import json; json.load(open('.claude-plugin/marketplace.json'))"` — confirm valid JSON
- [ ] Confirm `ref` matches current `version` in `plugin.json`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)