### PR TITLE
docs(rfcs): Implementation queue + cross-RFC settings.json coordination

### DIFF
--- a/docs/rfcs/AGENT-RULES.md
+++ b/docs/rfcs/AGENT-RULES.md
@@ -190,6 +190,7 @@ Any RFC status change or file move must update all of these:
 | `docs/README.md` | File Registry row (path, status, role) |
 | `docs/_index.json` | `path`, `status`, `role` fields |
 | `docs/references/_repo-context.md` | RFC list (draft / accepted / implemented / deferred) |
+| `rfcs/README.md` | `## Implementation queue` table — add a row when status moves to `accepted`; remove the row when status moves to `implemented`, `withdrawn`, or `superseded`. Re-order rows if dependency or sequencing changes. |
 | `rfcs/notes/README.md` | Remove entries for notes that moved to `archived/` |
 | `rfcs/pending-analysis.md` | Close resolved questions |
 

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -4,6 +4,26 @@ This directory manages the full lifecycle of RFCs and their companion discussion
 
 > **AI / Claude Code:** load [`AGENT-RULES.md`](AGENT-RULES.md) at the start of any session that involves creating, updating, moving, or closing an RFC. It contains the decision rules without the explanatory prose.
 
+> **AI / Claude Code:** before starting *any* implementation work on an accepted RFC (writing PRs, editing source files, running its scripts), first read the `## Implementation queue` section immediately below. Confirm with the user which RFC and which PR you are picking up.
+
+---
+
+## Implementation queue
+
+Accepted RFCs awaiting implementation, in recommended order. Pick up the first row first unless the user directs otherwise. Each RFC's full PR-level plan lives in its own `## Implementation plan` section.
+
+| Order | RFC | PRs | Why this position |
+|---|---|---|---|
+| 1 | [RFC-004 — Maintainer code-review enforcement](RFC-004-maintainer-code-review-enforcement.md) | 3 | Smaller scope; ships baseline maintainer-PR review discipline that protects every subsequent PR (including RFC-006's). Creates `.claude/settings.json` first — RFC-006 PR-5 then appends cleanly. |
+| 2 | [RFC-006 — RFC lifecycle quality gates and build-stage enforcement](RFC-006-rfc-lifecycle-quality-gates.md) | 8 | Larger scope (4 dependency tiers). Benefits from RFC-004's CI gate during its own implementation. PR-5 has explicit append-don't-overwrite coordination with RFC-004 PR-2. |
+
+**Cross-RFC coordination notes:**
+
+- **`.claude/settings.json` is shared.** RFC-004 PR-2 creates the file with a `Stop` hook entry; RFC-006 PR-5 appends a `PostToolUse` block. Whichever PR lands second must append, never overwrite. Both RFCs document this in their PR constraints.
+- **No new RFC may join the queue without going through `## Second opinion` and reaching `status: accepted`.** Adding a row here is part of the index-sync step in `AGENT-RULES.md §11`.
+
+**When an RFC moves to `implemented`:** remove its row from this table in the same change that moves the RFC file to `archived/`. Do not leave stale rows.
+
 ---
 
 ## Directory structure

--- a/docs/rfcs/RFC-004-maintainer-code-review-enforcement.md
+++ b/docs/rfcs/RFC-004-maintainer-code-review-enforcement.md
@@ -94,6 +94,12 @@ The two layers must not mix. This RFC establishes that pattern; future contribut
 
 Hard deps: PR-3 after PR-2 (share the same doc-only glob logic). PR-1 is independent.
 
+**Cross-RFC coordination — `.claude/settings.json` is shared with RFC-006 PR-5.** Either may land first:
+
+- _If PR-2 lands first_ (the expected order per `docs/rfcs/README.md` ## Implementation queue): create `.claude/settings.json` with a fresh `hooks.Stop` block containing the `code-review-gate.sh` entry. RFC-006 PR-5 will later append its `hooks.PostToolUse` block.
+- _If RFC-006 PR-5 has already merged_: the file already exists with a `hooks.PostToolUse` block. **Append** the new `hooks.Stop` block — do not recreate or overwrite the file.
+- Either path: run `python3 -m json.tool .claude/settings.json` (or equivalent) before commit to confirm the file parses.
+
 ---
 
 ## Implementation

--- a/docs/rfcs/RFC-006-rfc-lifecycle-quality-gates.md
+++ b/docs/rfcs/RFC-006-rfc-lifecycle-quality-gates.md
@@ -297,13 +297,20 @@ Eight PRs across four dependency tiers. Tier 1 PRs are independent and can ship 
 
 ### PR-5 — `.claude/settings.json` (Change 4 — register both hooks)
 
-**Before:** `.claude/settings.json` does not exist. `.claude/settings.local.json` exists separately (gitignored maintainer-local config — untouched).
+**Before:** two cases depending on RFC-004 PR-2 ordering:
+- _Case A — RFC-004 PR-2 has not yet landed:_ `.claude/settings.json` does not exist. `.claude/settings.local.json` exists separately (gitignored maintainer-local config — untouched).
+- _Case B — RFC-004 PR-2 has landed first:_ `.claude/settings.json` exists with a `hooks.Stop` entry for `code-review-gate.sh`. The `hooks.PostToolUse` array may not yet exist.
 
-**After:** new committed `.claude/settings.json` with a `hooks.PostToolUse` entry registering both `rfc-quality-gate.sh` and `ai-slop-check.sh` under matcher `Edit|Write|MultiEdit`, using `${CLAUDE_PROJECT_DIR}/.claude/hooks/...` paths.
+**After:** committed `.claude/settings.json` with a `hooks.PostToolUse` entry registering both `rfc-quality-gate.sh` and `ai-slop-check.sh` under matcher `Edit|Write|MultiEdit`, using `${CLAUDE_PROJECT_DIR}/.claude/hooks/...` paths.
+- _Case A:_ create the file with both `Stop` (placeholder for future) omitted and a fresh `hooks.PostToolUse` block containing the two entries.
+- _Case B:_ **append** the new `PostToolUse` block to the existing JSON. Do not overwrite or restructure RFC-004's `Stop` entry. Validate JSON parses after the edit.
 
-**Dependencies:** PR-3 and PR-4 (the registered scripts must exist).
+**Dependencies:** PR-3 and PR-4 (the registered scripts must exist). Soft ordering with RFC-004 PR-2: either may land first, but whichever lands second must append, not overwrite — see Constraints.
 
-**Constraints:** surgical — do not pre-register other future maintainer-only hooks (e.g. RFC-004's `code-review-gate.sh` gets its own registration PR).
+**Constraints:**
+- Surgical — do not pre-register other future maintainer-only hooks beyond the two from this RFC.
+- **Coordination with RFC-004 PR-2:** if RFC-004 PR-2 has already merged at the time PR-5 is opened, append the two new entries to the existing `.claude/settings.json` (do not recreate the file). If PR-5 lands first, RFC-004 PR-2 must do the symmetric append for its `Stop` entry.
+- Run `python3 -m json.tool .claude/settings.json` (or equivalent) before commit to confirm the file parses.
 
 ### PR-6 — `.claude/agents/rfc-pr-reviewer.md` (Change 6)
 


### PR DESCRIPTION
## Summary

- Adds `## Implementation queue` section to [`docs/rfcs/README.md`](docs/rfcs/README.md) — recommended order for accepted-but-not-yet-implemented RFCs (currently RFC-004 → RFC-006), with rationale and cross-RFC coordination notes. Read-before-implementing.
- Threads the queue into [`docs/rfcs/AGENT-RULES.md`](docs/rfcs/AGENT-RULES.md) §11 — any future RFC status change must add/remove the queue row in the same change as the other index files.
- RFC-004 PR-2 and RFC-006 PR-5 both gain symmetric "append-don't-overwrite" constraints for the shared `.claude/settings.json` — whichever lands second appends, never overwrites.

## Why

Two accepted RFCs (RFC-004, RFC-006) both touch `.claude/settings.json` and have ordering preferences. Without an authoritative queue, the next implementer would need to derive the order from scratch and could collide on the shared file.

## Test plan

- [ ] `python3 -m json.tool docs/_index.json` still parses (untouched here, sanity)
- [ ] `## Implementation queue` rows link correctly to RFC-004 and RFC-006
- [ ] AGENT-RULES.md §11 table renders cleanly with the new row
- [ ] No accidental scope creep into `sdlc-plugin/hooks/`, `sdlc-plugin/skills/`, `sdlc-plugin/agents/` (consuming-repo separation preserved)

Doc-only PR — bypasses RFC-004's planned code-review gate per the doc-only definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)