### PR TITLE
feat(rfc-004): PR-3 pre-merge-review-gate.sh + bats

### DIFF
--- a/.claude/hooks/pre-merge-review-gate.sh
+++ b/.claude/hooks/pre-merge-review-gate.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# pre-merge-review-gate.sh — Stop hook for maintainer pre-merge review gate.
+# Per RFC-004 + sdlc-plugin/AGENT-RULES.md §14.
+# Maintainer-only — installed in .claude/hooks/, not shipped to consuming repos.
+#
+# Behavior: warn (exit 0). Detects whether the current diff is doc-only;
+# for non-doc PRs, warns once per missing review artifact in .claude/sdlc/test/.
+set -euo pipefail
+
+# Stop hooks receive event JSON on stdin. We don't need it; read and discard
+# so we don't break a pipe upstream.
+[ -t 0 ] || cat > /dev/null 2>/dev/null || true
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+cd "$PROJECT_DIR" 2>/dev/null || exit 0
+
+# Must be in a git repo; gracefully degrade otherwise.
+git rev-parse --git-dir >/dev/null 2>&1 || exit 0
+
+# Determine the diff base. Fallback chain:
+#   origin/main → main → HEAD~1
+if git show-ref --verify --quiet refs/remotes/origin/main; then
+    BASE="origin/main"
+elif git show-ref --verify --quiet refs/heads/main; then
+    BASE="main"
+elif git rev-parse --verify --quiet HEAD~1 >/dev/null; then
+    BASE="HEAD~1"
+else
+    exit 0  # No base to diff against (single-commit repo).
+fi
+
+CHANGED_FILES=$(git diff --name-only "${BASE}...HEAD" 2>/dev/null || true)
+[ -n "$CHANGED_FILES" ] || exit 0  # No changes to gate.
+
+# Doc-only canonical glob (per RFC-004 + AGENT-RULES.md §14).
+# A PR is doc-only when EVERY changed file matches a doc pattern AND none
+# match the .claude/sdlc/plans/ or .claude/sdlc/gates/ exclusions.
+is_doc_only() {
+    local f
+    while IFS= read -r f; do
+        [ -z "$f" ] && continue
+        case "$f" in
+            .claude/sdlc/plans/*|.claude/sdlc/gates/*)
+                return 1  # Substantive governance file — treat as code-PR.
+                ;;
+            *.md|docs/*|templates/*|agents/*|commands/*|.github/*)
+                continue  # Doc pattern — keep checking other files.
+                ;;
+            *)
+                return 1  # Non-doc file found.
+                ;;
+        esac
+    done <<< "$CHANGED_FILES"
+    return 0
+}
+
+if is_doc_only; then
+    exit 0  # Doc-only PR — review gate bypassed.
+fi
+
+# Non-doc PR — verify all four review artifacts exist in .claude/sdlc/test/.
+TEST_DIR="${PROJECT_DIR}/.claude/sdlc/test"
+
+artifact_present() {
+    local pattern="$1"
+    [ -d "$TEST_DIR" ] || return 1
+    # shellcheck disable=SC2086
+    compgen -G "${TEST_DIR}/${pattern}" >/dev/null
+}
+
+warn_missing() {
+    local label="$1"
+    local agent="$2"
+    echo "[pre-merge-review] WARN: ${label} artifact missing in .claude/sdlc/test/ — run ${agent} per AGENT-RULES.md §14" >&2
+}
+
+artifact_present "security-review-*.md"      || warn_missing "security"      "maintainer-security-reviewer"
+artifact_present "code-quality-review-*.md"  || warn_missing "code-quality"  "maintainer-code-quality-reviewer"
+artifact_present "test-adequacy-review-*.md" || warn_missing "test-adequacy" "maintainer-test-adequacy-reviewer"
+artifact_present "dependency-review-*.md"    || warn_missing "dependency"    "maintainer-dependency-reviewer"
+
+exit 0

--- a/tests/hooks/pre_merge_review_gate.bats
+++ b/tests/hooks/pre_merge_review_gate.bats
@@ -1,0 +1,193 @@
+#!/usr/bin/env bats
+# Tests for .claude/hooks/pre-merge-review-gate.sh
+# Per RFC-004 PR-3 — maintainer-only Stop hook (warn, exit 0).
+
+setup() {
+  TEST_DIR=$(mktemp -d)
+  REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME}")/../.." && pwd)"
+  HOOK="$REPO_ROOT/.claude/hooks/pre-merge-review-gate.sh"
+
+  # Initialize a fresh git repo in the test dir with main branch + base commit.
+  git -C "$TEST_DIR" init -q -b main
+  git -C "$TEST_DIR" config user.email "test@example.com"
+  git -C "$TEST_DIR" config user.name "Test"
+  echo "base" > "$TEST_DIR/base.txt"
+  git -C "$TEST_DIR" add base.txt
+  git -C "$TEST_DIR" commit -q -m "base"
+
+  # Pre-create the artifact directory.
+  mkdir -p "$TEST_DIR/.claude/sdlc/test"
+
+  # Move onto a feature branch so HEAD~1 fallback resolves to the base commit.
+  git -C "$TEST_DIR" checkout -q -b feature
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+
+# Convenience: commit one or more files on the feature branch.
+commit_files() {
+  local msg="$1"; shift
+  for f in "$@"; do
+    mkdir -p "$(dirname "$TEST_DIR/$f")"
+    [ -e "$TEST_DIR/$f" ] || echo "x" > "$TEST_DIR/$f"
+    git -C "$TEST_DIR" add "$f"
+  done
+  git -C "$TEST_DIR" commit -q -m "$msg"
+}
+
+run_hook() {
+  CLAUDE_PROJECT_DIR="$TEST_DIR" run bash "$HOOK"
+}
+
+# -- 1. doc-only PRs bypass the gate --
+
+@test "doc-only PR (markdown only) bypasses gate, exits 0, no warnings" {
+  commit_files "docs" "README.md"
+  run_hook
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "doc-only PR (docs/ subdir) bypasses gate" {
+  commit_files "docs" "docs/foo.md"
+  run_hook
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "doc-only PR (templates/, agents/, commands/, .github/) bypasses gate" {
+  commit_files "mixed-doc" \
+    "templates/foo.md" \
+    "agents/bar.md" \
+    "commands/baz.md" \
+    ".github/workflows/qux.yml"
+  run_hook
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# -- 2. plan/gate exclusions are treated as code-PRs --
+
+@test ".claude/sdlc/plans/ touched is treated as code-PR — warns about all four artifacts" {
+  commit_files "plan" ".claude/sdlc/plans/foo.md"
+  run_hook
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"security artifact missing"* ]]
+  [[ "$output" == *"code-quality artifact missing"* ]]
+  [[ "$output" == *"test-adequacy artifact missing"* ]]
+  [[ "$output" == *"dependency artifact missing"* ]]
+}
+
+@test ".claude/sdlc/gates/ touched is treated as code-PR — warns about all four artifacts" {
+  commit_files "gate" ".claude/sdlc/gates/build-foo.md"
+  run_hook
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"security artifact missing"* ]]
+}
+
+# -- 3. code PR with all artifacts present passes silently --
+
+@test "code PR with all four artifacts present — exits 0, no warnings" {
+  commit_files "code" "foo.sh"
+  touch "$TEST_DIR/.claude/sdlc/test/security-review-foo.md"
+  touch "$TEST_DIR/.claude/sdlc/test/code-quality-review-foo.md"
+  touch "$TEST_DIR/.claude/sdlc/test/test-adequacy-review-foo.md"
+  touch "$TEST_DIR/.claude/sdlc/test/dependency-review-foo.md"
+  run_hook
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# -- 4. each individual missing artifact warns about that artifact only --
+
+@test "code PR missing security artifact — warns about security only" {
+  commit_files "code" "foo.sh"
+  touch "$TEST_DIR/.claude/sdlc/test/code-quality-review-foo.md"
+  touch "$TEST_DIR/.claude/sdlc/test/test-adequacy-review-foo.md"
+  touch "$TEST_DIR/.claude/sdlc/test/dependency-review-foo.md"
+  run_hook
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"security artifact missing"* ]]
+  [[ "$output" != *"code-quality artifact missing"* ]]
+  [[ "$output" != *"test-adequacy artifact missing"* ]]
+  [[ "$output" != *"dependency artifact missing"* ]]
+}
+
+@test "code PR missing code-quality artifact — warns about code-quality only" {
+  commit_files "code" "foo.sh"
+  touch "$TEST_DIR/.claude/sdlc/test/security-review-foo.md"
+  touch "$TEST_DIR/.claude/sdlc/test/test-adequacy-review-foo.md"
+  touch "$TEST_DIR/.claude/sdlc/test/dependency-review-foo.md"
+  run_hook
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"code-quality artifact missing"* ]]
+  [[ "$output" != *"security artifact missing"* ]]
+}
+
+@test "code PR missing test-adequacy artifact — warns about test-adequacy only" {
+  commit_files "code" "foo.sh"
+  touch "$TEST_DIR/.claude/sdlc/test/security-review-foo.md"
+  touch "$TEST_DIR/.claude/sdlc/test/code-quality-review-foo.md"
+  touch "$TEST_DIR/.claude/sdlc/test/dependency-review-foo.md"
+  run_hook
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"test-adequacy artifact missing"* ]]
+  [[ "$output" != *"security artifact missing"* ]]
+}
+
+@test "code PR missing dependency artifact — warns about dependency only" {
+  commit_files "code" "foo.sh"
+  touch "$TEST_DIR/.claude/sdlc/test/security-review-foo.md"
+  touch "$TEST_DIR/.claude/sdlc/test/code-quality-review-foo.md"
+  touch "$TEST_DIR/.claude/sdlc/test/test-adequacy-review-foo.md"
+  run_hook
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"dependency artifact missing"* ]]
+  [[ "$output" != *"security artifact missing"* ]]
+}
+
+@test "code PR missing all four — warns about all four" {
+  commit_files "code" "foo.sh"
+  run_hook
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"security artifact missing"* ]]
+  [[ "$output" == *"code-quality artifact missing"* ]]
+  [[ "$output" == *"test-adequacy artifact missing"* ]]
+  [[ "$output" == *"dependency artifact missing"* ]]
+}
+
+# -- 5. graceful degradation cases --
+
+@test "missing .claude/sdlc/test/ directory treated as all artifacts missing" {
+  commit_files "code" "foo.sh"
+  rm -rf "$TEST_DIR/.claude/sdlc/test"
+  run_hook
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"security artifact missing"* ]]
+  [[ "$output" == *"dependency artifact missing"* ]]
+}
+
+@test "dependency-review with Verdict: not-applicable artifact counts as present" {
+  commit_files "code" "foo.sh"
+  touch "$TEST_DIR/.claude/sdlc/test/security-review-foo.md"
+  touch "$TEST_DIR/.claude/sdlc/test/code-quality-review-foo.md"
+  touch "$TEST_DIR/.claude/sdlc/test/test-adequacy-review-foo.md"
+  cat > "$TEST_DIR/.claude/sdlc/test/dependency-review-foo.md" <<'ARTIFACT'
+**Reviewer:** maintainer-dependency-reviewer
+**Verdict:** not-applicable
+ARTIFACT
+  run_hook
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "outside a git repo — exits 0 silently" {
+  local non_repo
+  non_repo=$(mktemp -d)
+  CLAUDE_PROJECT_DIR="$non_repo" run bash "$HOOK"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+  rm -rf "$non_repo"
+}


### PR DESCRIPTION
## Summary

Implements RFC-004 PR-3 — maintainer-only Stop hook that warns once per missing review artifact in `.claude/sdlc/test/` when the current diff is not doc-only. Always exits 0 (WARN severity).

## Files

- `.claude/hooks/pre-merge-review-gate.sh` (new, executable, 73 lines)
- `tests/hooks/pre_merge_review_gate.bats` (new, 14 cases, all pass locally)

## Hook design

- POSIX-ish bash, `set -euo pipefail` (matches existing repo hook conventions)
- Diff base detection fallback: `origin/main` → `main` → `HEAD~1`
- Doc-only canonical glob (per [AGENT-RULES.md §14](sdlc-plugin/AGENT-RULES.md)): `*.md`, `docs/`, `templates/`, `agents/`, `commands/`, `.github/` — except `.claude/sdlc/plans/` and `.claude/sdlc/gates/` which are treated as code-PRs
- Glob-checks each artifact pattern: `security-review-*.md`, `code-quality-review-*.md`, `test-adequacy-review-*.md`, `dependency-review-*.md`
- Warning format: `[pre-merge-review] WARN: <type> artifact missing in .claude/sdlc/test/ — run maintainer-<type>-reviewer per AGENT-RULES.md §14`

## Graceful degradation

- Outside a git repo → exit 0 silently
- Single-commit repo (no `HEAD~1`) → exit 0 silently
- Missing `.claude/sdlc/test/` directory → all four artifacts treated as missing

## Test results (local)

```
1..14
ok 1 doc-only PR (markdown only) bypasses gate, exits 0, no warnings
ok 2 doc-only PR (docs/ subdir) bypasses gate
ok 3 doc-only PR (templates/, agents/, commands/, .github/) bypasses gate
ok 4 .claude/sdlc/plans/ touched is treated as code-PR — warns about all four artifacts
ok 5 .claude/sdlc/gates/ touched is treated as code-PR — warns about all four artifacts
ok 6 code PR with all four artifacts present — exits 0, no warnings
ok 7 code PR missing security artifact — warns about security only
ok 8 code PR missing code-quality artifact — warns about code-quality only
ok 9 code PR missing test-adequacy artifact — warns about test-adequacy only
ok 10 code PR missing dependency artifact — warns about dependency only
ok 11 code PR missing all four — warns about all four
ok 12 missing .claude/sdlc/test/ directory treated as all artifacts missing
ok 13 dependency-review with Verdict: not-applicable artifact counts as present
ok 14 outside a git repo — exits 0 silently
```

## Open question deferred

- **OQ-5 (artifact freshness check)** — out of scope for v1 per RFC-004 OQ-5 default. Hook checks presence only; revisit if stale-artifact false-passes are observed.

## Maintainer-vs-consuming separation

- All files under `.claude/hooks/` and `tests/hooks/` (maintainer-only)
- `sdlc-plugin/hooks/` untouched
- Plugin capability count (`hooks=14` in `sdlc-plugin/hooks/`) unchanged

## Dependencies

This PR depends on:
- [#34](https://github.com/lantisprime/claude-sdlc/pull/34) (queue plumbing)
- [#35](https://github.com/lantisprime/claude-sdlc/pull/35) (RFC-004 Revision 2)
- [#36](https://github.com/lantisprime/claude-sdlc/pull/36) (RFC-004 PR-1 + PR-2 — defines the artifact filenames this hook checks)

Branched off `rfc/004-pr1-pr2-section14-and-agents`. Merge order: #34 → #35 → #36 → rebase this PR onto main → merge.

## What's NOT in this PR

- PR-4: `.claude/settings.json` registration (Tier 3, depends on this PR)
- PR-5: `.github/workflows/pr-review.yml` (Tier 1, independent)

## Test plan

- [ ] `bats tests/hooks/pre_merge_review_gate.bats` passes (verified locally — 14/14)
- [ ] Hook is executable (`chmod +x` set in commit)
- [ ] No artifacts under `sdlc-plugin/hooks/` or `sdlc-plugin/agents/`
- [ ] Doc-only bypass glob matches AGENT-RULES.md §14 exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)