### PR TITLE
feat(rfc-004): PR-4 register pre-merge-review-gate.sh in .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "Tracked maintainer-only Claude Code settings for the sdlc-plugin repo. Registers hooks under .claude/hooks/ which run only in maintainer sessions on this repo (consuming repos do not load this file). Per RFC-004 PR-4. Cross-RFC coordination with RFC-006 PR-5: when RFC-006 lands, append a hooks.PostToolUse block here — do not overwrite this Stop block.",
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          { "type": "command", "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/pre-merge-review-gate.sh" }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Implements RFC-004 PR-4 — tracked Claude Code settings file registering PR-3's `pre-merge-review-gate.sh` under `hooks.Stop`.

## File

- `.claude/settings.json` (new, 12 lines)

## Path resolution

Uses `${CLAUDE_PROJECT_DIR}` — the project the maintainer is editing (this repo). This is distinct from `${CLAUDE_PLUGIN_ROOT}` used in `sdlc-plugin/hooks/hooks.json` (the consumer-shipped registration which points at the plugin install location). The two never collide.

## Cross-RFC coordination — `.claude/settings.json` is shared with RFC-006 PR-5

This PR lands first per the [Implementation queue](sdlc-plugin/docs/rfcs/README.md). It creates the file with the `hooks.Stop` block.

When RFC-006 PR-5 ships, it **appends** a `hooks.PostToolUse` block — never recreates or overwrites this file. The file's `_comment` field documents this for future contributors. RFC-006 PR-5's description already covers the "Case B — RFC-004 PR-4 landed first" path.

## Maintainer-vs-consuming separation

- `.claude/settings.json` is loaded by Claude Code only when working on the project that owns the file. Consuming repos using the installed plugin do not load it.
- `sdlc-plugin/hooks/hooks.json` (the plugin-shipped registration) is untouched.
- Plugin capability counts (`hooks=14`, `agents=5` in `sdlc-plugin/`) unchanged.

## Dependencies

This PR depends on:
- [#34](https://github.com/lantisprime/claude-sdlc/pull/34) (queue plumbing)
- [#35](https://github.com/lantisprime/claude-sdlc/pull/35) (RFC-004 Revision 2 design)
- [#36](https://github.com/lantisprime/claude-sdlc/pull/36) (PR-1 + PR-2)
- [#37](https://github.com/lantisprime/claude-sdlc/pull/37) (PR-3 — the hook script this file references must exist)

Branched off `rfc/004-pr3-pre-merge-review-hook`. Merge order: #34 → #35 → #36 → #37 → rebase this PR onto main → merge.

## Test plan

- [ ] `python3 -m json.tool .claude/settings.json` parses (verified locally)
- [ ] Hook path uses `${CLAUDE_PROJECT_DIR}` not `${CLAUDE_PLUGIN_ROOT}`
- [ ] No matcher field on the Stop hook entry (Stop hooks have no tool to match)
- [ ] `.claude/settings.json` is not in `.gitignore` (verified — only `.claude/sdlc/` patterns are mentioned and only as a note for consumers)
- [ ] `_comment` field flags the cross-RFC coordination for future contributors

## What's NOT in this PR

- PR-5: `.github/workflows/pr-review.yml` — the last RFC-004 PR (Tier-1, independent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)