### PR TITLE
feat(rfc-004): PR-5 pr-review.yml CI workflow (final RFC-004 PR)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,107 @@
+# PR Review Required — RFC-004 PR-5
+#
+# Maintainer-only CI gate. Requires ≥1 APPROVED GitHub review (from a
+# non-author) before a non-doc-only PR can merge to main. Doc-only PRs
+# pass automatically per the canonical glob shared with .claude/hooks/
+# pre-merge-review-gate.sh and sdlc-plugin/AGENT-RULES.md §14.
+#
+# IMPORTANT — branch protection (per RFC-004 OQ-2):
+#   This workflow runs but cannot block merge unless it is added to the
+#   *required status checks* on the `main` branch. After this workflow
+#   first runs successfully on a PR, mark it required by running:
+#
+#     gh api -X PATCH repos/${OWNER}/${REPO}/branches/main/protection \
+#       --input - <<'JSON'
+#     {
+#       "required_status_checks": {
+#         "strict": true,
+#         "contexts": ["pr-review / review-required"]
+#       },
+#       "enforce_admins": false,
+#       "required_pull_request_reviews": null,
+#       "restrictions": null
+#     }
+#     JSON
+#
+#   Or via the GitHub UI: Settings → Branches → main → "Require status
+#   checks to pass before merging" → add `pr-review / review-required`.
+#
+# Without this branch-protection step, the gate is advisory only.
+
+name: pr-review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+  pull_request_review:
+    types: [submitted, dismissed]
+
+# Cancel superseded runs on the same PR (re-pushes, re-reviews) so the
+# latest commit is always the one that determines pass/fail.
+concurrency:
+  group: pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review-required:
+    # Skip drafts entirely — drafts are explicitly WIP.
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine doc-only PR
+        id: doc-only
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          CHANGED=$(git diff --name-only "${BASE_SHA}...HEAD")
+          DOC_ONLY=true
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              # Substantive governance files — treat as code-PR even though they are .md.
+              .claude/sdlc/plans/*|.claude/sdlc/gates/*)
+                DOC_ONLY=false; break ;;
+              # Doc patterns — same canonical glob as .claude/hooks/pre-merge-review-gate.sh
+              # and sdlc-plugin/AGENT-RULES.md §14. Keep all three in sync.
+              *.md|docs/*|templates/*|agents/*|commands/*|.github/*)
+                continue ;;
+              *)
+                DOC_ONLY=false; break ;;
+            esac
+          done <<< "$CHANGED"
+          echo "doc_only=${DOC_ONLY}" >> "$GITHUB_OUTPUT"
+          echo "Doc-only: ${DOC_ONLY}"
+          echo "Files changed:"
+          echo "$CHANGED" | sed 's/^/  /'
+
+      - name: Pass — doc-only PR
+        if: steps.doc-only.outputs.doc_only == 'true'
+        run: echo "Doc-only PR — review not required (per AGENT-RULES.md §14)."
+
+      - name: Require approved non-author review
+        if: steps.doc-only.outputs.doc_only == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          set -euo pipefail
+          # Count APPROVED reviews where the reviewer is not the PR author.
+          # Self-approval is filtered (per RFC-004).
+          COUNT=$(gh api \
+            "repos/${{ github.repository }}/pulls/${PR_NUMBER}/reviews" \
+            --jq "[.[] | select(.state == \"APPROVED\" and .user.login != \"${PR_AUTHOR}\")] | length")
+          echo "Approved non-author reviews: ${COUNT}"
+          if [ "${COUNT}" -lt 1 ]; then
+            echo "::error::At least 1 approved review from a non-author is required for code PRs (per sdlc-plugin/AGENT-RULES.md §14 / RFC-004)."
+            exit 1
+          fi
+          echo "Review requirement satisfied."


### PR DESCRIPTION
## Summary

Implements RFC-004 PR-5 — the final PR in the multi-reviewer gate. GitHub Actions workflow that requires ≥1 APPROVED review from a non-author before a non-doc-only PR can merge to main.

## File

- `.github/workflows/pr-review.yml` (new, 107 lines)

## Behavior

- **Triggers:** `pull_request: [opened, synchronize, ready_for_review, reopened]` + `pull_request_review: [submitted, dismissed]`. The latter is essential — without it, the check would stay red after a reviewer approves until the next push.
- **Skips drafts entirely** (`github.event.pull_request.draft == false`) per direction — drafts are explicitly WIP.
- **Doc-only bypass** uses the canonical glob shared with PR-3's `pre-merge-review-gate.sh` and AGENT-RULES.md §14: `*.md|docs/*|templates/*|agents/*|commands/*|.github/*` — except `.claude/sdlc/plans/*` and `.claude/sdlc/gates/*` which are excluded.
- **Code-PRs:** query `gh api repos/${{ github.repository }}/pulls/${PR_NUMBER}/reviews`, count APPROVED reviews where `user.login != PR_AUTHOR`, fail with `::error::` annotation when count < 1.
- **Concurrency:** superseded runs cancelled so the latest commit/review always determines pass/fail.

## OQ-2 resolution — branch protection

Header comment documents that the workflow runs but cannot block merge unless added to required status checks on `main`. Includes the exact `gh api -X PATCH` invocation to do so:

```bash
gh api -X PATCH repos/${OWNER}/${REPO}/branches/main/protection \
  --input - <<'JSON'
{
  "required_status_checks": {
    "strict": true,
    "contexts": ["pr-review / review-required"]
  },
  ...
}
JSON
```

After this workflow first runs successfully on a PR (so the check exists in GitHub's "available checks" list), the maintainer must run that command to actually enforce the gate.

## Doc-only glob in 3 places (must stay in sync)

| File | Purpose |
|---|---|
| `sdlc-plugin/AGENT-RULES.md §14` | Canonical rule for maintainer Build gate sign-off |
| `.claude/hooks/pre-merge-review-gate.sh` (PR-3) | Local Stop hook check |
| `.github/workflows/pr-review.yml` (this PR) | CI gate |

A future PR could extract the glob into a single source (e.g. a tiny script all three call), but per RFC-004 OQ-5 default ("present-only for v1") this is out of scope.

## Permissions

- `contents: read` (checkout)
- `pull-requests: read` (`gh api` list reviews)

No write permissions — gate is read-only on PR state.

## Maintainer-vs-consuming separation

- Workflow lives in `.github/workflows/` of this repo only — does not ship to consuming repos.
- `sdlc-plugin/` artifacts unchanged.
- Plugin capability counts (`hooks=14`, `agents=5`) unchanged.

## Dependencies

This PR depends on:
- [#34](https://github.com/lantisprime/claude-sdlc/pull/34) (queue plumbing)
- [#35](https://github.com/lantisprime/claude-sdlc/pull/35) (RFC-004 Revision 2 design)
- [#36](https://github.com/lantisprime/claude-sdlc/pull/36) (PR-1 + PR-2)
- [#37](https://github.com/lantisprime/claude-sdlc/pull/37) (PR-3 hook)
- [#38](https://github.com/lantisprime/claude-sdlc/pull/38) (PR-4 settings.json)

Branched off `rfc/004-pr4-settings-registration`. Merge order: #34 → #35 → #36 → #37 → #38 → rebase this PR onto main → merge.

## Once this merges

RFC-004 is fully implemented. Per AGENT-RULES.md §5, the next steps:
1. Populate `## Implementation` table in RFC-004 with PR links/commits
2. Move RFC: `rfcs/RFC-004-...md` → `rfcs/archived/RFC-004-...md`
3. Update §11 index files: `docs/README.md` (move row), `docs/_index.json` (path + role), `docs/references/_repo-context.md` (capability counts unchanged), `docs/rfcs/README.md` (remove from queue)
4. Run the `gh api` branch-protection command from the workflow header

## Test plan

- [ ] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr-review.yml'))"` parses (verified locally — 107 lines)
- [ ] `actionlint` clean (not installed locally — will rely on GitHub's native validation on push)
- [ ] Doc-only glob matches the other two sources exactly
- [ ] Self-approval filter present (`user.login != PR_AUTHOR`)
- [ ] Drafts skipped (`if: github.event.pull_request.draft == false`)
- [ ] First successful run + branch-protection PATCH after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)