### PR TITLE
docs(rfc-template): reconcile Implementation plan format with §3b — RFC-006 PR-1

### DIFF
--- a/docs/rfcs/TEMPLATE.md
+++ b/docs/rfcs/TEMPLATE.md
@@ -47,15 +47,30 @@ Document every alternative that was seriously considered and explain concisely w
 
 ## Implementation plan
 
-> Populate this section when the RFC moves to `accepted`. Aim for under 50 lines — list phases, files in scope per phase, and PR sequence. Do not repeat design rationale already covered above.
+> Populate this section when the RFC moves to `accepted`. Use `### PR-N — <file(s)>` subheadings (per `AGENT-RULES.md §3b`).
+> For each PR: a **Before** block (current state or "file does not exist"), an **After** block (exact diff, skeleton, or section outline), one-line **Dependencies** note, and key **Constraints**. Close with a **Sequencing** diagram (Mermaid).
 
-| Phase | PRs / tasks | Files in scope |
-|---|---|---|
-| 1 | _example: create hook script_ | `hooks/example.sh` |
-| 2 | _example: register hook_ | `hooks/hooks.json` |
+### PR-1 — _example: hooks/example.sh_
 
-Sequencing notes:
-- _list any hard dependencies between phases_
+**Before:** _file does not exist_
+
+**After:** _new script — sketch its responsibility in 2–4 lines (skeleton, function signatures, or expected behavior). Reference the exact file path._
+
+**Dependencies:** _none_
+
+**Constraints:** _e.g. POSIX bash, no GNU-only flags; backwards-compatible with older config schema; surgical scope_
+
+### Sequencing
+
+```mermaid
+graph TD
+    PR1[PR-1: example.sh]
+    PR2[PR-2: registration]
+
+    PR1 --> PR2
+```
+
+> Adjust nodes per actual PR count. Use `classDef` to colour-code dependency tiers if helpful (e.g. `tier1` for parallel-ready PRs, `tier2` for those depending on a tier-1 PR, etc.).
 
 ---
 


### PR DESCRIPTION
## Summary

First implementation PR for RFC-006 (Change 2). Replaces the table-based `## Implementation plan` placeholder in `docs/rfcs/TEMPLATE.md` with the `### PR-N` subheading format prescribed by `docs/rfcs/AGENT-RULES.md §3b` (authoritative decision source).

## Why

RFC-006 Gap 3 flagged a divergence: `TEMPLATE.md` showed a `| Phase | PRs / tasks | Files in scope |` table, while `AGENT-RULES.md §3b` instructed `### PR-N` subheadings with **Before**/**After** blocks and a Mermaid Sequencing diagram. Either format was legal, which meant the future `rfc-quality-gate.sh` hook (RFC-006 PR-3) couldn't reliably check that the plan exists at acceptance. Reconciling once is cheap; carrying ambiguity forever is not.

## What's new in TEMPLATE.md `## Implementation plan`

```markdown
### PR-1 — _example: hooks/example.sh_

**Before:** _file does not exist_

**After:** _new script — sketch its responsibility in 2–4 lines …_

**Dependencies:** _none_

**Constraints:** _e.g. POSIX bash, no GNU-only flags; …_

### Sequencing

` ` `mermaid
graph TD
    PR1[PR-1: example.sh]
    PR2[PR-2: registration]
    PR1 --> PR2
` ` `

> Adjust nodes per actual PR count. Use `classDef` to colour-code dependency tiers …
```

## Forward-only

Per RFC-006 PR-1 constraint: existing accepted RFCs that used the table format are NOT retro-edited. Verified:

- **RFC-001** (accepted) — uses table format → unchanged
- **RFC-005** (draft) — uses table format → unchanged
- **RFC-004** (now archived) — used `### PR-N` already → consistent
- **RFC-006** (accepted) — uses `### PR-N` already → consistent

Future RFCs drafted from this template inherit the §3b-aligned format.

## Maintainer-vs-consuming separation

This change touches `docs/rfcs/TEMPLATE.md` only — used exclusively by maintainers when authoring new RFCs. No `sdlc-plugin/` artifacts touched. No capability count changes.

## Test plan

- [ ] `git diff` shows only `docs/rfcs/TEMPLATE.md` modified (verified — single file, +22/-7)
- [ ] New `### PR-1` skeleton matches the format in `AGENT-RULES.md §3b` and used in RFC-004 (Implementation plan)
- [ ] Mermaid example renders correctly in GitHub preview
- [ ] No retro-edit of RFC-001 / RFC-005 table format

Doc-only PR — should classify as doc-only via `*.md` glob and pass the new `pr-review` gate automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)