### PR TITLE
feat(maintainer-config): register rfc-quality-gate.sh + ai-slop-check.sh — RFC-006 PR-5

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,10 +1,19 @@
 {
-  "_comment": "Tracked maintainer-only Claude Code settings for the sdlc-plugin repo. Registers hooks under .claude/hooks/ which run only in maintainer sessions on this repo (consuming repos do not load this file). Per RFC-004 PR-4. Cross-RFC coordination with RFC-006 PR-5: when RFC-006 lands, append a hooks.PostToolUse block here — do not overwrite this Stop block.",
+  "_comment": "Tracked maintainer-only Claude Code settings for the sdlc-plugin repo. Registers hooks under .claude/hooks/ which run only in maintainer sessions on this repo (consuming repos do not load this file). Per RFC-004 PR-4 (Stop) and RFC-006 PR-5 (PostToolUse). Future hook additions must append to the existing Stop or PostToolUse arrays — never overwrite either block.",
   "hooks": {
     "Stop": [
       {
         "hooks": [
           { "type": "command", "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/pre-merge-review-gate.sh" }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          { "type": "command", "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/rfc-quality-gate.sh" },
+          { "type": "command", "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/ai-slop-check.sh" }
         ]
       }
     ]


### PR DESCRIPTION
## Summary

- Appends a `hooks.PostToolUse` block to `.claude/settings.json` registering the two maintainer-only hooks merged in RFC-006 PR-3 (#43) and PR-4 (#44).
- Preserves the `hooks.Stop` block from RFC-004 PR-4 (#38) untouched — sibling addition, not re-nesting.
- Rewrites `_comment` to credit both RFCs and to warn future contributors that additions must append to existing arrays, never overwrite.

Implements **RFC-006 PR-5** (Tier 2 in the dependency graph). Tier-1 deps PR-3 (#43) and PR-4 (#44) are merged. RFC-004 PR-4's `Stop` block is the Case B starting state from the RFC's PR-5 spec.

## Why this shape

Both hooks self-filter internally:

- `rfc-quality-gate.sh` exits 0 unless the path matches `*/docs/rfcs/*.md` (excluding `TEMPLATE.md`, `README.md`, `pending-analysis.md`, `notes/**`, `archived/**`).
- `ai-slop-check.sh` exits 0 unless the path matches `*.md` under `docs/` or `rfcs/`.

This means the broad `Edit|Write|MultiEdit` matcher is safe — non-RFC writes incur only a fork+exit per hook. Per RFC-006 §Change 4 ("no separate matchers are needed").

## Validation

- `python3 -m json.tool .claude/settings.json` — parses cleanly.
- `tests/run.sh` — 5/5 suites pass (182 bats tests, including `rfc_quality_gate.bats` and `ai_slop_check.bats` which simulate the PostToolUse JSON shape end-to-end).

## Second-opinion review

Performed pre-PR by an independent subagent. Verdict: **proceed**. Two nits:

1. `NotebookEdit` not in the matcher — left as RFC-spec verbatim (hooks self-filter to `*.md` so notebook writes would no-op anyway).
2. Original `_comment` carried a "do not overwrite" coordination warning — restored in the rewritten comment so the discipline survives future hook additions.

No blockers found.

## Test plan

- [x] `python3 -m json.tool .claude/settings.json` exits 0
- [x] `tests/run.sh` — all suites pass
- [ ] Post-merge manual check: edit a `docs/rfcs/RFC-*.md` file in a maintainer session and confirm both `[rfc-gate]` and `[ai-slop]` warnings can fire (depending on file content)
- [ ] Post-merge manual check: edit `docs/rfcs/TEMPLATE.md` and confirm `rfc-quality-gate.sh` self-filters out (TEMPLATE is excluded), `ai-slop-check.sh` may scan
- [ ] Post-merge manual check: edit a non-RFC `.md` file outside `docs/` and confirm both hooks self-filter out

🤖 Generated with [Claude Code](https://claude.com/claude-code)