### PR TITLE
chore(scripts): add bot-review.sh for routine --comment reviews

### DIFF
--- a/scripts/bot-approve.sh
+++ b/scripts/bot-approve.sh
@@ -2,8 +2,14 @@
 set -euo pipefail
 
 # Approves a PR as the bot account (lantiscooperdev) to satisfy branch
-# protection's "required non-author approval" rule when the maintainer
-# (lantisprime) is the only human contributor.
+# protection's "required non-author approval" rule.
+#
+# BREAK-GLASS ONLY. Routine PR review uses scripts/bot-review.sh which
+# posts a --comment-state review (no approval, doesn't satisfy the gate).
+# This script submits an APPROVE review, satisfying the non-author review
+# gate without user input — run only when the user explicitly authorizes
+# a bot approve (e.g. workflow auto-commit PRs from CI, or unblocking a
+# stuck merge with prior consent).
 #
 # Usage: scripts/bot-approve.sh <PR#> [body]
 

--- a/scripts/bot-review.sh
+++ b/scripts/bot-review.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Posts a substantive --comment-state review on a PR using the bot account
+# (lantiscooperdev), so findings appear in the PR's Reviews tab WITHOUT
+# satisfying the "non-author review" gate. Routine flow — agent runs this
+# automatically after `gh pr create`.
+#
+# For approval (BREAK-GLASS only — never routine), see scripts/bot-approve.sh.
+#
+# Usage: scripts/bot-review.sh <PR#> <body>
+
+MAINTAINER="lantisprime"
+BOT="lantiscooperdev"
+
+if [ $# -lt 2 ]; then
+  echo "usage: $0 <PR#> <body>" >&2
+  echo "       body must be substantive — checks performed, suggestions, risks, verdict." >&2
+  exit 1
+fi
+
+PR_NUM="$1"
+BODY="$2"
+
+command -v gh >/dev/null 2>&1 || { echo "error: gh CLI required" >&2; exit 1; }
+
+gh auth status 2>&1 | grep -q "account ${BOT}" \
+  || { echo "error: ${BOT} not authenticated in gh — run 'gh auth login'" >&2; exit 1; }
+gh auth status 2>&1 | grep -q "account ${MAINTAINER}" \
+  || { echo "error: ${MAINTAINER} not authenticated in gh" >&2; exit 1; }
+
+PR_AUTHOR=$(gh pr view "$PR_NUM" --json author --jq '.author.login')
+if [ "$PR_AUTHOR" = "$BOT" ]; then
+  echo "error: PR #${PR_NUM} is authored by ${BOT} — bot cannot review its own PR" >&2
+  exit 1
+fi
+
+restore_maintainer() {
+  gh auth switch -u "$MAINTAINER" >/dev/null 2>&1 || true
+}
+trap restore_maintainer EXIT
+
+gh auth switch -u "$BOT" >/dev/null
+gh pr review "$PR_NUM" --comment --body "$BODY"
+echo "comment-review posted on PR #${PR_NUM} as ${BOT}"


### PR DESCRIPTION
## Summary

Adds `scripts/bot-review.sh` for the new agent-after-PR-open flow. The bot account posts a substantive `--comment` review on every PR so findings appear in the Reviews tab; the user approves manually. `bot-approve.sh` stays in place but is now explicitly break-glass only.

Companion to user-preferences repo commit [`7467df2`](https://github.com/lantisprime/user-preferences/commit/7467df2) which updates Rule 17 to "Bot reviews; user approves."

## Files

- **`scripts/bot-review.sh`** (new, +47) — posts `gh pr review --comment` using lantiscooperdev. Same auth-switch + trap-restore pattern as bot-approve.sh; refuses to run if PR author is the bot.
- **`scripts/bot-approve.sh`** (docstring +6/-2) — header rewritten to "BREAK-GLASS ONLY" with explicit pointer to bot-review.sh for routine use. Logic unchanged.

## Why

After PR-48 was merged using `bot-approve.sh` to clear `review-required`, the user clarified the desired flow: bot DOES review automatically (so the user has analytical second-opinion findings on the PR), but bot does NOT approve. A `--comment` review satisfies the first need without violating the second. `--approve` reviews stay reserved for explicit break-glass.

## Validation

- `tests/run.sh` — all 5 suites pass (no test changes; scripts dir not exercised by bats).
- Script is `chmod +x`.
- Manual lint: matches bot-approve.sh's auth-switch/trap pattern verbatim except for `--comment` vs `--approve`.

## Test plan

- [x] `tests/run.sh` green
- [ ] After merge, run `scripts/bot-review.sh 49 "<body>"` against the open PR-7 to demonstrate the loop end-to-end
- [ ] Verify the resulting review shows up in PR-49's Reviews tab as state=COMMENTED, not APPROVED
- [ ] Verify `gh pr checks 49` still shows `review-required` as failing (bot --comment must NOT clear the gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)