### PR TITLE
docs(rfc-006): catch up Implementation table with PR-1..PR-7 rows

### DIFF
--- a/docs/rfcs/RFC-006-rfc-lifecycle-quality-gates.md
+++ b/docs/rfcs/RFC-006-rfc-lifecycle-quality-gates.md
@@ -384,13 +384,13 @@ graph TD
 
 | PR | Files changed | Review verdict | Tests | Slop |
 |---|---|---|---|---|
-| _pending_ | _pending_ | _pending_ | _pending_ | _pending_ |
-| _pending_ | _pending_ | _pending_ | _pending_ | _pending_ |
-| _pending_ | _pending_ | _pending_ | _pending_ | _pending_ |
-| _pending_ | _pending_ | _pending_ | _pending_ | _pending_ |
-| _pending_ | _pending_ | _pending_ | _pending_ | _pending_ |
-| _pending_ | _pending_ | _pending_ | _pending_ | _pending_ |
-| _pending_ | `docs/rfcs/AGENT-RULES.md`, `docs/rfcs/TEMPLATE.md`, `.claude/hooks/rfc-quality-gate.sh`, `tests/hooks/rfc_quality_gate.bats` | _pending_ | pass | flagged:[pre-existing FPs in Change 7 slop-pattern docs only; PR-7 lines clean] |
+| [#41](https://github.com/lantisprime/claude-sdlc/pull/41) | `docs/rfcs/TEMPLATE.md` | n/a (pre-§3.5) | n/a (no code) | n/a (pre-§3.5) |
+| [#42](https://github.com/lantisprime/claude-sdlc/pull/42) | `docs/rfcs/AGENT-RULES.md` | n/a (pre-§3.5) | n/a (no code) | n/a (pre-§3.5) |
+| [#43](https://github.com/lantisprime/claude-sdlc/pull/43) | `.claude/hooks/rfc-quality-gate.sh`, `tests/hooks/rfc_quality_gate.bats` | n/a (pre-§3.5) | pass | n/a (no docs) |
+| [#44](https://github.com/lantisprime/claude-sdlc/pull/44) | `.claude/hooks/ai-slop-check.sh`, `tests/hooks/ai_slop_check.bats` | n/a (pre-§3.5) | pass | n/a (no docs) |
+| [#45](https://github.com/lantisprime/claude-sdlc/pull/45) | `.claude/agents/rfc-pr-reviewer.md` | n/a (pre-§3.5) | n/a (no code) | n/a (pre-§3.5) |
+| [#48](https://github.com/lantisprime/claude-sdlc/pull/48) | `.claude/settings.json` | n/a (pre-§3.5) | pass (5/5 suites) | n/a (no docs) |
+| [#49](https://github.com/lantisprime/claude-sdlc/pull/49) | `docs/rfcs/AGENT-RULES.md`, `docs/rfcs/TEMPLATE.md`, `docs/rfcs/RFC-006-rfc-lifecycle-quality-gates.md`, `.claude/hooks/rfc-quality-gate.sh`, `tests/hooks/rfc_quality_gate.bats` | n/a (pre-§3.5) | pass (184/184) | flagged:[pre-existing FPs in Change 7 slop-pattern docs only; PR-7 lines clean] |
 | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ |
 
 Key files changed:


### PR DESCRIPTION
## Summary

Catches up RFC-006's `## Implementation` table. Six rows had `_pending_` placeholders even though their PRs had shipped (#41, #42, #43, #44, #45, #48); PR-7 (#49) had partial data. This commit fills in `PR | Files | Verdict | Tests | Slop` for all seven rows. Row 8 (PR-8) stays `_pending_` — to be filled in after PR-8 merges.

Single file changed: `docs/rfcs/RFC-006-rfc-lifecycle-quality-gates.md`. +7/-7.

## Why now

Per AGENT-RULES.md §3.5 / §5: "mark each PR row immediately after it merges." That instruction was retroactive for PRs 1–6 (they merged before §3.5 existed), and only partially applied to PR-7. With PR-7 merged, the table should reflect the actual shipped state before PR-8 closes the RFC.

## Vocabulary note — `n/a (pre-§3.5)`

§3.5 step 5 closed verdict vocabulary is `approved | changes-requested | concerns:[…] | n/a (docs-only)`. None of those captures "this PR shipped before the build-stage loop existed." Used `n/a (pre-§3.5)` as an honest extension. PR-8 may want to formalise this token in the §3.5 closed set, or leave it as a one-off bridging value for the RFC-006 transition.

## Row data

| PR | What it shipped |
|---|---|
| [#41](https://github.com/lantisprime/claude-sdlc/pull/41) | TEMPLATE.md format reconciled to §3b shape (Change 2) |
| [#42](https://github.com/lantisprime/claude-sdlc/pull/42) | Gate checklists added to AGENT-RULES.md §2–§7 (Change 3) |
| [#43](https://github.com/lantisprime/claude-sdlc/pull/43) | rfc-quality-gate.sh + bats tests (Change 1) |
| [#44](https://github.com/lantisprime/claude-sdlc/pull/44) | ai-slop-check.sh + bats tests (Change 7) |
| [#45](https://github.com/lantisprime/claude-sdlc/pull/45) | rfc-pr-reviewer.md agent (Haiku 4.5, Change 6) |
| [#48](https://github.com/lantisprime/claude-sdlc/pull/48) | settings.json registers both hooks (Change 4) |
| [#49](https://github.com/lantisprime/claude-sdlc/pull/49) | §3.5 Building loop + stub-detection extension (Change 5) |

## Validation

- `tests/run.sh` — 5/5 suites pass (no test impact; pure docs change).
- `git diff --stat`: 1 file, +7/-7. No other files touched.
- `last_modified` already matches today (2026-04-30) — no frontmatter bump needed.

## Test plan

- [x] Run `tests/run.sh`
- [ ] Post-merge: confirm `[rfc-gate]` doesn't WARN about stub rows on next RFC-006 edit (it shouldn't — table now has real data, no `_pending_` entries except row 8 which is still legitimately pending)

## Out of scope

- Formalising `n/a (pre-§3.5)` into the §3.5 closed vocabulary (PR-8 if desired).
- Filling in PR-8's row (it hasn't shipped).
- Status change to `implemented` or move to `archived/` (PR-8's job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)