### PR TITLE
feat(rfc-second-opinion): tighten §3a with AI-slop check field — RFC-006 PR-8

### DIFF
--- a/docs/rfcs/AGENT-RULES.md
+++ b/docs/rfcs/AGENT-RULES.md
@@ -76,12 +76,17 @@ Record findings in `## Second opinion`:
 **Reviewer:** <name or "self-review">
 **Date:** YYYY-MM-DD
 **Findings:** [gaps surfaced, alternatives missed, risks not captured — or "no gaps found"]
+**AI-slop check:** clean | fixed in revision | concerns:[<list>]
 **Decision:** proceed | revise first
 ```
 
-If the decision is `revise first`, address the gaps before setting `status: accepted`.
+**Decision rules:**
 
-> **Preferred approach:** spawn an independent subagent to perform the review rather than self-reviewing. An agent with no prior context on the RFC surfaces risks and alternatives that familiarity obscures.
+- `**Decision:** proceed` is permitted only when `**AI-slop check:**` is `clean` or `fixed in revision`.
+- If `**AI-slop check:** concerns:[<list>]` is recorded, `**Decision:** proceed` is forbidden — must be `revise first` until the concerns are resolved or fixed in revision.
+- If the decision is `revise first` (whether due to slop concerns or any other gaps), address the gaps before setting `status: accepted`.
+
+> **Preferred approach:** spawn an independent subagent to perform the review rather than self-reviewing. An agent with no prior context on the RFC surfaces risks and alternatives that familiarity obscures. The slop-check pass should default to **Haiku 4.5** for cost discipline (matching Change 6 of RFC-006: ~1–3k tokens per review vs. ~10–15k on Sonnet).
 
 **3b. After second opinion clears:**
 

--- a/docs/rfcs/TEMPLATE.md
+++ b/docs/rfcs/TEMPLATE.md
@@ -101,6 +101,7 @@ Key files changed (high-level summary, populated when status moves to `implement
 **Reviewer:** <!-- name or "self-review" -->
 **Date:** <!-- YYYY-MM-DD -->
 **Findings:** <!-- gaps surfaced, alternatives missed, risks not captured — or "no gaps found" -->
+**AI-slop check:** <!-- clean | fixed in revision | concerns:[<list>] -->
 **Decision:** <!-- proceed | revise first -->
 
 ---


### PR DESCRIPTION
## Summary

Implements **RFC-006 PR-8** — the last code/docs-shipping PR of RFC-006. Adds a required `**AI-slop check:**` field to the `## Second opinion` block in both `AGENT-RULES.md §3a` and `TEMPLATE.md`, and tightens §3a's decision rules so `**Decision:** proceed` is forbidden when slop-check concerns remain unresolved.

Two files, +8/-2.

## Changes

### 1. `docs/rfcs/AGENT-RULES.md` §3a

The fenced `## Second opinion` markdown block (lines 73–80) gains a 5th field after `**Findings:**`:

```diff
 **Reviewer:** <name or "self-review">
 **Date:** YYYY-MM-DD
 **Findings:** [gaps surfaced, alternatives missed, risks not captured — or "no gaps found"]
+**AI-slop check:** clean | fixed in revision | concerns:[<list>]
 **Decision:** proceed | revise first
```

The "If the decision is `revise first`..." paragraph is replaced with explicit decision rules:

```diff
-If the decision is `revise first`, address the gaps before setting `status: accepted`.
+**Decision rules:**
+
+- `**Decision:** proceed` is permitted only when `**AI-slop check:**` is `clean` or `fixed in revision`.
+- If `**AI-slop check:** concerns:[<list>]` is recorded, `**Decision:** proceed` is forbidden — must be `revise first` until the concerns are resolved or fixed in revision.
+- If the decision is `revise first` (whether due to slop concerns or any other gaps), address the gaps before setting `status: accepted`.
```

The `> **Preferred approach:**` callout gains a Haiku 4.5 default note:

```diff
-> **Preferred approach:** spawn an independent subagent to perform the review rather than self-reviewing. An agent with no prior context on the RFC surfaces risks and alternatives that familiarity obscures.
+> **Preferred approach:** spawn an independent subagent to perform the review rather than self-reviewing. An agent with no prior context on the RFC surfaces risks and alternatives that familiarity obscures. The slop-check pass should default to **Haiku 4.5** for cost discipline (matching Change 6 of RFC-006: ~1–3k tokens per review vs. ~10–15k on Sonnet).
```

### 2. `docs/rfcs/TEMPLATE.md` `## Second opinion`

Mirrors the AGENT-RULES.md change — adds the matching `**AI-slop check:**` field after `**Findings:**`:

```diff
 **Reviewer:** <!-- name or "self-review" -->
 **Date:** <!-- YYYY-MM-DD -->
 **Findings:** <!-- gaps surfaced, alternatives missed, risks not captured — or "no gaps found" -->
+**AI-slop check:** <!-- clean | fixed in revision | concerns:[<list>] -->
 **Decision:** <!-- proceed | revise first -->
```

## Why same commit

Per RFC-006 PR-8 constraint (line 343): "AGENT-RULES.md and TEMPLATE.md must change in the same commit (parser parity — `rfc-quality-gate.sh` from PR-3 will be extended in a follow-up to check for the new `**AI-slop check:**` line; the template must already emit the field)."

The grep extension to `rfc-quality-gate.sh` is **not** in this PR — it's an in-scope follow-up since OQ-2 of RFC-006 deferred this concern, and shipping the parser change without first having the source data field would be premature.

## Validation

- `tests/run.sh` — 5/5 suites pass. No logic change; bats coverage of rfc-quality-gate.sh is unaffected (the hook still doesn't grep for the new field — by design, that's a follow-up).
- AGENT-RULES.md §3a renders correctly with the 5-field markdown block + decision-rules list.
- TEMPLATE.md `## Second opinion` parses as well-formed markdown with the new HTML comment placeholder.

## Test plan

- [x] `tests/run.sh` passes
- [ ] Post-merge: any RFC drafted from TEMPLATE.md going forward emits the `**AI-slop check:**` line by default
- [ ] Post-merge: spot-check that AGENT-RULES.md §3a renders correctly in GitHub's markdown preview

## Out of scope

- **Extending `rfc-quality-gate.sh`** to grep for `**AI-slop check:**` — separate follow-up. The template must emit the field first; the parser can come later.
- **Retroactive edits** to existing accepted/archived RFCs that don't have the field. Forward-only constraint stands.
- **RFC-006 close-out** — separate PR (PR-8b: status→implemented, move to archived/, sync §11 index files).

## What's next for RFC-006

Once #N merges, the close-out PR (PR-8b) will:
1. Mark this PR's row in RFC-006's `## Implementation` table.
2. Flip `status: accepted` → `status: implemented`.
3. `git mv` to `docs/rfcs/archived/`.
4. Sync `docs/README.md`, `docs/_index.json`, `docs/references/_repo-context.md`, `docs/rfcs/README.md`, `docs/references/workflow-log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)